### PR TITLE
Feature/logo

### DIFF
--- a/assets/logo-options/01-shield-clock.svg
+++ b/assets/logo-options/01-shield-clock.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="shieldGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#818CF8"/>
+      <stop offset="100%" stop-color="#4F46E5"/>
+    </linearGradient>
+    <linearGradient id="clockGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#E0E7FF"/>
+      <stop offset="100%" stop-color="#C7D2FE"/>
+    </linearGradient>
+  </defs>
+  <!-- Shield body -->
+  <path d="M256 28 L456 108 C456 108 468 300 256 484 C44 300 56 108 56 108 Z"
+        fill="url(#shieldGrad)" stroke="none"/>
+  <!-- Inner shield highlight -->
+  <path d="M256 60 L428 128 C428 128 438 292 256 452 C74 292 84 128 84 128 Z"
+        fill="none" stroke="#818CF8" stroke-width="4" opacity="0.5"/>
+  <!-- Clock circle -->
+  <circle cx="256" cy="240" r="120" fill="#1E1B4B" opacity="0.9"/>
+  <circle cx="256" cy="240" r="108" fill="none" stroke="url(#clockGrad)" stroke-width="6"/>
+  <!-- Hour markers -->
+  <line x1="256" y1="144" x2="256" y2="160" stroke="#C7D2FE" stroke-width="6" stroke-linecap="round"/>
+  <line x1="256" y1="320" x2="256" y2="336" stroke="#C7D2FE" stroke-width="6" stroke-linecap="round"/>
+  <line x1="160" y1="240" x2="176" y2="240" stroke="#C7D2FE" stroke-width="6" stroke-linecap="round"/>
+  <line x1="336" y1="240" x2="352" y2="240" stroke="#C7D2FE" stroke-width="6" stroke-linecap="round"/>
+  <!-- Clock hands -->
+  <line x1="256" y1="240" x2="256" y2="172" stroke="#E0E7FF" stroke-width="8" stroke-linecap="round"/>
+  <line x1="256" y1="240" x2="308" y2="210" stroke="#E0E7FF" stroke-width="6" stroke-linecap="round"/>
+  <!-- Center dot -->
+  <circle cx="256" cy="240" r="8" fill="#818CF8"/>
+</svg>

--- a/assets/logo-options/02-lock-timer.svg
+++ b/assets/logo-options/02-lock-timer.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="lockBodyGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#818CF8"/>
+      <stop offset="100%" stop-color="#4F46E5"/>
+    </linearGradient>
+    <linearGradient id="shackleGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#6366F1"/>
+    </linearGradient>
+  </defs>
+  <!-- Lock shackle (U-shape) -->
+  <path d="M168 220 L168 148 C168 80 208 40 256 40 C304 40 344 80 344 148 L344 220"
+        fill="none" stroke="url(#shackleGrad)" stroke-width="36" stroke-linecap="round"/>
+  <!-- Lock body (rounded rectangle) -->
+  <rect x="120" y="220" width="272" height="252" rx="40" ry="40"
+        fill="url(#lockBodyGrad)"/>
+  <!-- Timer arc on lock body -->
+  <circle cx="256" cy="340" r="72" fill="none" stroke="#1E1B4B" stroke-width="16" opacity="0.4"/>
+  <!-- Timer progress arc (270 degrees = 3/4 complete) -->
+  <path d="M256 268 A72 72 0 1 1 184 340"
+        fill="none" stroke="#E0E7FF" stroke-width="16" stroke-linecap="round"/>
+  <!-- Timer tick marks -->
+  <line x1="256" y1="276" x2="256" y2="288" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="320" y1="340" x2="308" y2="340" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="256" y1="404" x2="256" y2="392" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="192" y1="340" x2="204" y2="340" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <!-- Timer hand -->
+  <line x1="256" y1="340" x2="256" y2="288" stroke="#E0E7FF" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="256" cy="340" r="6" fill="#E0E7FF"/>
+</svg>

--- a/assets/logo-options/03-prohibition-web.svg
+++ b/assets/logo-options/03-prohibition-web.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="circleGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#818CF8"/>
+      <stop offset="100%" stop-color="#4F46E5"/>
+    </linearGradient>
+    <linearGradient id="globeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#C7D2FE"/>
+      <stop offset="100%" stop-color="#A5B4FC"/>
+    </linearGradient>
+  </defs>
+  <!-- Globe/web icon (simplified) -->
+  <circle cx="256" cy="256" r="140" fill="none" stroke="url(#globeGrad)" stroke-width="10" opacity="0.5"/>
+  <!-- Globe vertical meridian -->
+  <ellipse cx="256" cy="256" rx="70" ry="140" fill="none" stroke="url(#globeGrad)" stroke-width="8" opacity="0.5"/>
+  <!-- Globe horizontal lines -->
+  <line x1="116" y1="210" x2="396" y2="210" stroke="#A5B4FC" stroke-width="6" opacity="0.4"/>
+  <line x1="116" y1="302" x2="396" y2="302" stroke="#A5B4FC" stroke-width="6" opacity="0.4"/>
+  <!-- Globe equator -->
+  <line x1="116" y1="256" x2="396" y2="256" stroke="#A5B4FC" stroke-width="7" opacity="0.45"/>
+  <!-- Prohibition circle (outer) -->
+  <circle cx="256" cy="256" r="200" fill="none" stroke="url(#circleGrad)" stroke-width="40"/>
+  <!-- Prohibition diagonal slash -->
+  <line x1="114" y1="398" x2="398" y2="114"
+        stroke="url(#circleGrad)" stroke-width="40" stroke-linecap="round"/>
+</svg>

--- a/assets/logo-options/04-hourglass-shield.svg
+++ b/assets/logo-options/04-hourglass-shield.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="shieldGrad4" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#818CF8"/>
+      <stop offset="100%" stop-color="#4F46E5"/>
+    </linearGradient>
+    <linearGradient id="sandGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#E0E7FF"/>
+      <stop offset="100%" stop-color="#C7D2FE"/>
+    </linearGradient>
+    <linearGradient id="glassGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#E0E7FF"/>
+      <stop offset="100%" stop-color="#A5B4FC"/>
+    </linearGradient>
+  </defs>
+  <!-- Shield body -->
+  <path d="M256 28 L456 108 C456 108 468 300 256 484 C44 300 56 108 56 108 Z"
+        fill="url(#shieldGrad4)" stroke="none"/>
+  <!-- Shield inner border -->
+  <path d="M256 60 L428 128 C428 128 438 292 256 452 C74 292 84 128 84 128 Z"
+        fill="#1E1B4B" opacity="0.6"/>
+  <!-- Hourglass top triangle -->
+  <path d="M176 128 L336 128 L256 248 Z"
+        fill="none" stroke="url(#glassGrad)" stroke-width="10" stroke-linejoin="round"/>
+  <!-- Hourglass bottom triangle -->
+  <path d="M176 380 L336 380 L256 260 Z"
+        fill="none" stroke="url(#glassGrad)" stroke-width="10" stroke-linejoin="round"/>
+  <!-- Sand in top (partial) -->
+  <path d="M208 128 L304 128 L256 204 Z"
+        fill="url(#sandGrad)" opacity="0.4"/>
+  <!-- Sand in bottom (more full) -->
+  <path d="M196 380 L316 380 L256 296 Z"
+        fill="url(#sandGrad)" opacity="0.7"/>
+  <!-- Sand stream -->
+  <line x1="256" y1="248" x2="256" y2="296" stroke="#E0E7FF" stroke-width="4" opacity="0.8"/>
+  <!-- Top cap -->
+  <line x1="168" y1="128" x2="344" y2="128" stroke="#E0E7FF" stroke-width="8" stroke-linecap="round"/>
+  <!-- Bottom cap -->
+  <line x1="168" y1="380" x2="344" y2="380" stroke="#E0E7FF" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/assets/logo-options/05-stylized-s.svg
+++ b/assets/logo-options/05-stylized-s.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="sGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#818CF8"/>
+      <stop offset="50%" stop-color="#6366F1"/>
+      <stop offset="100%" stop-color="#4F46E5"/>
+    </linearGradient>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1E1B4B"/>
+      <stop offset="100%" stop-color="#312E81"/>
+    </linearGradient>
+    <linearGradient id="lockAccent" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#6366F1"/>
+    </linearGradient>
+  </defs>
+  <!-- Rounded square background -->
+  <rect x="32" y="32" width="448" height="448" rx="96" ry="96"
+        fill="url(#bgGrad)"/>
+  <!-- Subtle inner border -->
+  <rect x="48" y="48" width="416" height="416" rx="84" ry="84"
+        fill="none" stroke="#6366F1" stroke-width="2" opacity="0.3"/>
+  <!-- Stylized S shape - geometric, constructed from curves -->
+  <path d="M320 140
+           C320 140 340 140 340 140
+           C340 140 340 140 320 140
+           L192 140
+           C152 140 128 168 128 200
+           C128 232 152 260 192 260
+           L320 260
+           C360 260 384 288 384 320
+           C384 352 360 380 320 380
+           L192 380
+           C172 380 172 380 192 380"
+        fill="none" stroke="url(#sGrad)" stroke-width="0" opacity="0"/>
+  <!-- Clean geometric S -->
+  <path d="M336 136 L196 136 C156 136 128 164 128 200 C128 236 156 264 196 264 L316 264 C356 264 384 292 384 328 C384 364 356 392 316 392 L176 392"
+        fill="none" stroke="url(#sGrad)" stroke-width="44" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Lock keyhole on the S curve - positioned at center -->
+  <circle cx="256" cy="264" r="18" fill="#1E1B4B"/>
+  <rect x="249" y="264" width="14" height="24" rx="4" fill="#1E1B4B"/>
+  <!-- Small lock shackle hint at top -->
+  <path d="M232 148 L232 112 C232 92 244 80 256 80 C268 80 280 92 280 112 L280 148"
+        fill="none" stroke="url(#lockAccent)" stroke-width="12" stroke-linecap="round"/>
+</svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="lockBodyGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#818CF8"/>
+      <stop offset="100%" stop-color="#4F46E5"/>
+    </linearGradient>
+    <linearGradient id="shackleGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#6366F1"/>
+    </linearGradient>
+  </defs>
+  <!-- Lock shackle (U-shape) -->
+  <path d="M168 220 L168 148 C168 80 208 40 256 40 C304 40 344 80 344 148 L344 220"
+        fill="none" stroke="url(#shackleGrad)" stroke-width="36" stroke-linecap="round"/>
+  <!-- Lock body (rounded rectangle) -->
+  <rect x="120" y="220" width="272" height="252" rx="40" ry="40"
+        fill="url(#lockBodyGrad)"/>
+  <!-- Timer arc on lock body -->
+  <circle cx="256" cy="340" r="72" fill="none" stroke="#1E1B4B" stroke-width="16" opacity="0.4"/>
+  <!-- Timer progress arc (270 degrees = 3/4 complete) -->
+  <path d="M256 268 A72 72 0 1 1 184 340"
+        fill="none" stroke="#E0E7FF" stroke-width="16" stroke-linecap="round"/>
+  <!-- Timer tick marks -->
+  <line x1="256" y1="276" x2="256" y2="288" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="320" y1="340" x2="308" y2="340" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="256" y1="404" x2="256" y2="392" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="192" y1="340" x2="204" y2="340" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <!-- Timer hand -->
+  <line x1="256" y1="340" x2="256" y2="288" stroke="#E0E7FF" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="256" cy="340" r="6" fill="#E0E7FF"/>
+</svg>

--- a/scripts/generate_icns.sh
+++ b/scripts/generate_icns.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+# Generate AppIcon.icns from assets/logo.svg
+# Requires: rsvg-convert (from librsvg, install via: brew install librsvg)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+SVG_SOURCE="$PROJECT_ROOT/assets/logo.svg"
+ICONSET_DIR="$PROJECT_ROOT/assets/AppIcon.iconset"
+OUTPUT="$PROJECT_ROOT/assets/AppIcon.icns"
+
+if ! command -v rsvg-convert &> /dev/null; then
+  echo "Error: rsvg-convert not found. Install with: brew install librsvg"
+  exit 1
+fi
+
+echo "Generating .icns from $SVG_SOURCE..."
+
+rm -rf "$ICONSET_DIR"
+mkdir -p "$ICONSET_DIR"
+
+# macOS icon sizes required for .icns
+sizes=(16 32 64 128 256 512)
+for size in "${sizes[@]}"; do
+  rsvg-convert -w "$size" -h "$size" "$SVG_SOURCE" -o "$ICONSET_DIR/icon_${size}x${size}.png"
+  echo "  Created ${size}x${size}"
+done
+
+# Retina variants
+retina_pairs=("16 32" "32 64" "128 256" "256 512" "512 1024")
+for pair in "${retina_pairs[@]}"; do
+  base=$(echo "$pair" | cut -d' ' -f1)
+  actual=$(echo "$pair" | cut -d' ' -f2)
+  rsvg-convert -w "$actual" -h "$actual" "$SVG_SOURCE" -o "$ICONSET_DIR/icon_${base}x${base}@2x.png"
+  echo "  Created ${base}x${base}@2x (${actual}px)"
+done
+
+# Generate .icns
+iconutil -c icns "$ICONSET_DIR" -o "$OUTPUT"
+rm -rf "$ICONSET_DIR"
+
+echo "Done: $OUTPUT"

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="lockBodyGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#818CF8"/>
+      <stop offset="100%" stop-color="#4F46E5"/>
+    </linearGradient>
+    <linearGradient id="shackleGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#6366F1"/>
+    </linearGradient>
+  </defs>
+  <path d="M168 220 L168 148 C168 80 208 40 256 40 C304 40 344 80 344 148 L344 220"
+        fill="none" stroke="url(#shackleGrad)" stroke-width="36" stroke-linecap="round"/>
+  <rect x="120" y="220" width="272" height="252" rx="40" ry="40"
+        fill="url(#lockBodyGrad)"/>
+  <circle cx="256" cy="340" r="72" fill="none" stroke="#1E1B4B" stroke-width="16" opacity="0.4"/>
+  <path d="M256 268 A72 72 0 1 1 184 340"
+        fill="none" stroke="#E0E7FF" stroke-width="16" stroke-linecap="round"/>
+  <line x1="256" y1="276" x2="256" y2="288" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="320" y1="340" x2="308" y2="340" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="256" y1="404" x2="256" y2="392" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="192" y1="340" x2="204" y2="340" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="256" y1="340" x2="256" y2="288" stroke="#E0E7FF" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="256" cy="340" r="6" fill="#E0E7FF"/>
+</svg>

--- a/web/src/assets/logo.svg
+++ b/web/src/assets/logo.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="lockBodyGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#818CF8"/>
+      <stop offset="100%" stop-color="#4F46E5"/>
+    </linearGradient>
+    <linearGradient id="shackleGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#A5B4FC"/>
+      <stop offset="100%" stop-color="#6366F1"/>
+    </linearGradient>
+  </defs>
+  <!-- Lock shackle (U-shape) -->
+  <path d="M168 220 L168 148 C168 80 208 40 256 40 C304 40 344 80 344 148 L344 220"
+        fill="none" stroke="url(#shackleGrad)" stroke-width="36" stroke-linecap="round"/>
+  <!-- Lock body (rounded rectangle) -->
+  <rect x="120" y="220" width="272" height="252" rx="40" ry="40"
+        fill="url(#lockBodyGrad)"/>
+  <!-- Timer arc on lock body -->
+  <circle cx="256" cy="340" r="72" fill="none" stroke="#1E1B4B" stroke-width="16" opacity="0.4"/>
+  <!-- Timer progress arc (270 degrees = 3/4 complete) -->
+  <path d="M256 268 A72 72 0 1 1 184 340"
+        fill="none" stroke="#E0E7FF" stroke-width="16" stroke-linecap="round"/>
+  <!-- Timer tick marks -->
+  <line x1="256" y1="276" x2="256" y2="288" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="320" y1="340" x2="308" y2="340" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="256" y1="404" x2="256" y2="392" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <line x1="192" y1="340" x2="204" y2="340" stroke="#C7D2FE" stroke-width="4" stroke-linecap="round"/>
+  <!-- Timer hand -->
+  <line x1="256" y1="340" x2="256" y2="288" stroke="#E0E7FF" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="256" cy="340" r="6" fill="#E0E7FF"/>
+</svg>


### PR DESCRIPTION
This pull request introduces a new script to automate the generation of macOS `.icns` icon files from an SVG logo, improving the developer workflow for creating app icons. Additionally, it updates a subproject commit reference.

**Icon generation automation:**

* Added a new script `scripts/generate_icns.sh` that converts `assets/logo.svg` into a properly sized `.icns` file for macOS, including all required icon sizes and retina variants. The script checks for dependencies and provides clear instructions and output.

**Subproject update:**

* Updated the subproject commit reference in `.claude/worktrees/mighty-tumbling-matsumoto` to point to a new commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project submodule reference
  * Enhanced macOS icon generation automation for improved build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->