### PR TITLE
feat: add troubleshooting section to README and improve integration t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Landing page: `https://gilbertsahumada.github.io/self-control/`
 
 Release instructions: see `RELEASE.md`.
 
+## Troubleshooting
+
+If sites remain blocked after the timer expires, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for diagnosis and manual cleanup steps.
+
 ## Security
 
 - Input validation for custom domains (prevents injection)

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -3,7 +3,7 @@
 # Requires: sudo, macOS (uses /etc/hosts and pf).
 # Runs on GitHub Actions macos-14 runner or locally with sudo.
 
-set -euo pipefail
+set -uo pipefail
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -20,8 +20,8 @@ TEST_SITES=("x.com" "instagram.com" "youtube.com")
 
 # --- Helpers ---
 
-log()  { echo -e "${GREEN}[PASS]${NC} $1"; ((PASS++)); }
-fail() { echo -e "${RED}[FAIL]${NC} $1"; ((FAIL++)); }
+log()  { echo -e "${GREEN}[PASS]${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; FAIL=$((FAIL + 1)); }
 info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
 
 cleanup() {
@@ -52,11 +52,11 @@ trap cleanup EXIT
 check_dns() {
     local domain="$1"
     # Returns 0 if domain resolves to a real IP (not 127.0.0.1)
-    local result
-    result=$(dscacheutil -q host -a name "$domain" 2>/dev/null | grep "ip_address:" | head -1 | awk '{print $2}')
+    local result=""
+    result=$(dscacheutil -q host -a name "$domain" 2>/dev/null | grep "ip_address:" | head -1 | awk '{print $2}' || true)
     if [[ -z "$result" ]]; then
         # dscacheutil didn't return anything, try host command
-        result=$(host "$domain" 2>/dev/null | grep "has address" | head -1 | awk '{print $NF}')
+        result=$(host "$domain" 2>/dev/null | grep "has address" | head -1 | awk '{print $NF}' || true)
     fi
     if [[ "$result" == "127.0.0.1" ]]; then
         return 1  # Blocked
@@ -76,8 +76,8 @@ echo "========================================"
 echo ""
 
 # Verify we have sudo
-if ! sudo -n true 2>/dev/null; then
-    echo "Error: This script requires passwordless sudo (CI) or run with sudo."
+if [[ $EUID -ne 0 ]] && ! sudo -n true 2>/dev/null; then
+    echo "Error: This script requires root. Run with: sudo $0"
     exit 1
 fi
 
@@ -127,7 +127,7 @@ fi
 
 # Verify DNS now resolves to 127.0.0.1
 for site in "${TEST_SITES[@]}"; do
-    resolved=$(dscacheutil -q host -a name "$site" 2>/dev/null | grep "ip_address:" | head -1 | awk '{print $2}')
+    resolved=$(dscacheutil -q host -a name "$site" 2>/dev/null | grep "ip_address:" | head -1 | awk '{print $2}' || true)
     if [[ "$resolved" == "127.0.0.1" ]]; then
         log "BLOCKED: $site resolves to 127.0.0.1"
     else
@@ -169,7 +169,7 @@ fi
 # Verify sites resolve again after cleanup
 sleep 2
 for site in "${TEST_SITES[@]}"; do
-    resolved=$(host "$site" 8.8.8.8 2>/dev/null | grep "has address" | head -1 | awk '{print $NF}')
+    resolved=$(host "$site" 8.8.8.8 2>/dev/null | grep "has address" | head -1 | awk '{print $NF}' || true)
     if [[ -n "$resolved" && "$resolved" != "127.0.0.1" ]]; then
         log "UNBLOCKED: $site resolves to $resolved"
     else


### PR DESCRIPTION
This pull request improves the integration test script for reliability and usability, and adds troubleshooting documentation for users. The main changes include making the script more robust against command failures, improving how it checks for root privileges, and updating the documentation to help users resolve issues with blocked sites.

**Integration test script reliability and usability:**

* The script now allows commands in pipelines to fail without stopping execution by removing the `-e` option from `set -euo pipefail`, which prevents the script from exiting on non-zero status in pipelines.
* All uses of command substitution for checking DNS resolution (`dscacheutil` and `host`) now append `|| true` to avoid script errors if the command fails or returns no result. [[1]](diffhunk://#diff-04a82e40ebe59c2140090275278cca1f75de61dd099b6b6ebdfaf201584fe87eL55-R59) [[2]](diffhunk://#diff-04a82e40ebe59c2140090275278cca1f75de61dd099b6b6ebdfaf201584fe87eL130-R130) [[3]](diffhunk://#diff-04a82e40ebe59c2140090275278cca1f75de61dd099b6b6ebdfaf201584fe87eL172-R172)
* The script now checks for root privileges using `$EUID` and provides a clearer error message instructing users to run the script with `sudo` if not root.
* The increment logic for `PASS` and `FAIL` counters is updated to use arithmetic expansion for better portability and clarity.

**Documentation improvements:**

* Added a "Troubleshooting" section to `README.md` with a link to `TROUBLESHOOTING.md` for diagnosis and manual cleanup steps if sites remain blocked after the timer expires.