### PR TITLE
fix: wait 90s for daemon cleanup before showing stale-block banner

### DIFF
--- a/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
+++ b/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
@@ -245,10 +245,10 @@ class BlockViewModel: ObservableObject {
                 self.remainingSeconds = 0
                 self.selectedSites = []
                 self.customSitesText = ""
-                // Give daemons a few seconds to run their cleanup, then verify.
-                DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
-                    self?.checkExistingBlock()
-                }
+                // Poll the hosts file for up to `postExpiryGraceSeconds` so the
+                // LaunchDaemon has time to run cleanup before we surface the
+                // stale-block banner. Normal path: banner never appears.
+                self.startPostExpiryPolling()
             } else {
                 self.remainingSeconds = remaining
                 if remaining <= 60 && interval != 1 {

--- a/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
+++ b/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
@@ -116,6 +116,34 @@ class BlockViewModel: ObservableObject {
         }
     }
 
+    /// Polls `/etc/hosts` every `postExpiryPollInterval` for up to
+    /// `postExpiryGraceSeconds` after block expiry before surfacing the
+    /// stale-block banner. In the normal path the enforcer daemon cleans
+    /// up within 60s and the banner never appears.
+    private func startPostExpiryPolling() {
+        postExpiryPollTimer?.invalidate()
+        postExpiryDeadline = Date().addingTimeInterval(Self.postExpiryGraceSeconds)
+        isWaitingForDaemonCleanup = true
+        needsRecoveryCleanup = false
+
+        postExpiryPollTimer = Timer.scheduledTimer(withTimeInterval: Self.postExpiryPollInterval, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            if !self.detectStaleBlock() {
+                self.postExpiryPollTimer?.invalidate()
+                self.postExpiryPollTimer = nil
+                self.isWaitingForDaemonCleanup = false
+                self.needsRecoveryCleanup = false
+                return
+            }
+            if let deadline = self.postExpiryDeadline, Date() >= deadline {
+                self.postExpiryPollTimer?.invalidate()
+                self.postExpiryPollTimer = nil
+                self.isWaitingForDaemonCleanup = false
+                self.needsRecoveryCleanup = true
+            }
+        }
+    }
+
     /// Returns true if /etc/hosts still contains MonkMode markers without an active block.
     /// This indicates the enforcer daemon failed to clean up on expiry.
     private func detectStaleBlock() -> Bool {

--- a/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
+++ b/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
@@ -22,8 +22,18 @@ class BlockViewModel: ObservableObject {
     @Published var isProcessing: Bool = false
     @Published var errorMessage: String?
     @Published var needsRecoveryCleanup: Bool = false
+    @Published var isWaitingForDaemonCleanup: Bool = false
+
+    /// Seconds after timer expiry during which we suppress the stale-block
+    /// banner while polling to give the LaunchDaemon time to run cleanup.
+    /// The primary enforcer daemon runs every 60s so 90s gives a full cycle
+    /// plus launchd wake-up slack.
+    static let postExpiryGraceSeconds: TimeInterval = 90
+    static let postExpiryPollInterval: TimeInterval = 10
 
     private var timer: Timer?
+    private var postExpiryPollTimer: Timer?
+    private var postExpiryDeadline: Date?
 
     init() {
         checkExistingBlock()

--- a/Sources/BlockSitesApp/Views/SetupView.swift
+++ b/Sources/BlockSitesApp/Views/SetupView.swift
@@ -20,7 +20,9 @@ struct SetupView: View {
                     promptLine
                     Divider().background(Theme.phosphorMuted)
 
-                    if viewModel.needsRecoveryCleanup {
+                    if viewModel.isWaitingForDaemonCleanup {
+                        waitingBanner
+                    } else if viewModel.needsRecoveryCleanup {
                         recoveryBanner
                     }
 
@@ -108,6 +110,24 @@ struct SetupView: View {
             .shadow(color: Theme.phosphorGlow, radius: 3)
             .lineSpacing(-2)
             .fixedSize(horizontal: true, vertical: true)
+    }
+
+    private var waitingBanner: some View {
+        HStack(spacing: 8) {
+            Text("..")
+                .font(Theme.monoSM.weight(.bold))
+                .foregroundColor(Theme.phosphorDim)
+            Text("waiting for daemon cleanup")
+                .font(Theme.monoSM)
+                .foregroundColor(Theme.phosphorDim)
+            Spacer()
+            Text("polling...")
+                .font(Theme.monoSM)
+                .foregroundColor(Theme.phosphorMuted)
+        }
+        .padding(10)
+        .background(Theme.surface)
+        .overlay(Rectangle().stroke(Theme.phosphorMuted, lineWidth: 1))
     }
 
     private var recoveryBanner: some View {


### PR DESCRIPTION
## Summary

The recovery banner was firing 5 seconds after the timer hit zero, but the enforcer LaunchDaemon runs on a 60-second tick — so users saw a false-positive "STALE LOCKDOWN DETECTED" banner during the window between expiry and the daemon's next run.

This PR polls \`/etc/hosts\` every 10 seconds for up to 90 seconds after expiry. If the daemon cleans up within that window (the normal path), the banner never appears. Only if the hosts file is still dirty after 90 seconds do we surface the recovery UI.

Adds a small "waiting for daemon cleanup" status during the grace window so the user sees the app is still tracking state.

## Test plan
- [x] \`swift build\` — clean
- [x] \`swift test\` — 144 tests passing
- [ ] Manual: start a 1-minute block, let it expire, verify no banner
- [ ] Manual: kill daemon mid-block, let timer expire, verify banner appears after 90s