### PR TITLE
feat: replace comma-separated custom domains with chip input

### DIFF
--- a/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
+++ b/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
@@ -6,7 +6,9 @@ class BlockViewModel: ObservableObject {
     // MARK: - Setup State
 
     @Published var selectedSites: Set<String> = []
-    @Published var customSitesText: String = ""
+    @Published var customDomains: [String] = []
+    @Published var pendingDomainInput: String = ""
+    @Published var pendingDomainError: String?
     @Published var hours: Int = 0
     @Published var minutes: Int = 30
 
@@ -42,20 +44,9 @@ class BlockViewModel: ObservableObject {
     // MARK: - Computed Properties
 
     var allSitesToBlock: [String] {
-        let (valid, _) = DomainValidator.validateAndClean(customSitesText
-            .split(separator: ",")
-            .map { String($0) })
         var sites = Array(selectedSites)
-        sites.append(contentsOf: valid)
+        sites.append(contentsOf: customDomains)
         return Array(Set(sites)).sorted()
-    }
-
-    var invalidDomains: [String] {
-        let custom = customSitesText
-            .split(separator: ",")
-            .map { String($0) }
-        let (_, invalid) = DomainValidator.validateAndClean(custom)
-        return invalid
     }
 
     var totalDurationSeconds: TimeInterval {
@@ -244,7 +235,9 @@ class BlockViewModel: ObservableObject {
                 self.config = nil
                 self.remainingSeconds = 0
                 self.selectedSites = []
-                self.customSitesText = ""
+                self.customDomains = []
+                self.pendingDomainInput = ""
+                self.pendingDomainError = nil
                 // Poll the hosts file for up to `postExpiryGraceSeconds` so the
                 // LaunchDaemon has time to run cleanup before we surface the
                 // stale-block banner. Normal path: banner never appears.

--- a/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
+++ b/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
@@ -57,6 +57,41 @@ class BlockViewModel: ObservableObject {
         !allSitesToBlock.isEmpty && totalDurationSeconds > 0
     }
 
+    // MARK: - Custom Domain Input
+
+    /// Validates `pendingDomainInput` and appends it to `customDomains` on
+    /// success. Publishes `pendingDomainError` on failure so the UI can
+    /// render inline feedback. Accepts one domain per call; splitting on
+    /// whitespace/comma is handled by the view before calling.
+    @discardableResult
+    func commitPendingDomain() -> Bool {
+        let raw = pendingDomainInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else {
+            pendingDomainError = nil
+            return false
+        }
+
+        let (valid, invalid) = DomainValidator.validateAndClean([raw])
+        guard let cleaned = valid.first else {
+            pendingDomainError = "invalid domain: \(invalid.first ?? raw)"
+            return false
+        }
+
+        if customDomains.contains(cleaned) || selectedSites.contains(cleaned) {
+            pendingDomainError = "already in list: \(cleaned)"
+            return false
+        }
+
+        customDomains.append(cleaned)
+        pendingDomainInput = ""
+        pendingDomainError = nil
+        return true
+    }
+
+    func removeCustomDomain(_ domain: String) {
+        customDomains.removeAll { $0 == domain }
+    }
+
     var progress: Double {
         guard let config = config else { return 0 }
         let total = config.endTime.timeIntervalSince(config.startTime)

--- a/Sources/BlockSitesApp/Views/DomainChip.swift
+++ b/Sources/BlockSitesApp/Views/DomainChip.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct DomainChip: View {
+    let domain: String
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(domain)
+                .font(Theme.monoSM.weight(.semibold))
+                .foregroundColor(Theme.phosphor)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Button(action: onRemove) {
+                Text("×")
+                    .font(Theme.mono(14, weight: .bold))
+                    .foregroundColor(Theme.phosphorDim)
+                    .frame(width: 16, height: 16)
+            }
+            .buttonStyle(.plain)
+            .help("Remove \(domain)")
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Theme.phosphor.opacity(0.1))
+        .overlay(Rectangle().stroke(Theme.phosphor, lineWidth: 1))
+    }
+}

--- a/Sources/BlockSitesApp/Views/FlowLayout.swift
+++ b/Sources/BlockSitesApp/Views/FlowLayout.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// Wraps children onto the next line when they exceed the available width.
+/// Used to lay out the variable-length domain chip row.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 6
+    var runSpacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let rows = arrange(subviews: subviews, in: maxWidth)
+        let height = rows.reduce(CGFloat(0)) { acc, row in
+            acc + row.height + (acc > 0 ? runSpacing : 0)
+        }
+        return CGSize(width: maxWidth.isFinite ? maxWidth : rows.map { $0.width }.max() ?? 0, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = arrange(subviews: subviews, in: bounds.width)
+        var y = bounds.minY
+        for row in rows {
+            var x = bounds.minX
+            for item in row.items {
+                item.view.place(
+                    at: CGPoint(x: x, y: y),
+                    anchor: .topLeading,
+                    proposal: ProposedViewSize(width: item.size.width, height: item.size.height)
+                )
+                x += item.size.width + spacing
+            }
+            y += row.height + runSpacing
+        }
+    }
+
+    private struct Row {
+        var items: [(view: LayoutSubview, size: CGSize)] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    private func arrange(subviews: Subviews, in maxWidth: CGFloat) -> [Row] {
+        var rows: [Row] = [Row()]
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            var current = rows[rows.count - 1]
+            let projected = current.width + (current.items.isEmpty ? 0 : spacing) + size.width
+            if projected > maxWidth && !current.items.isEmpty {
+                rows.append(Row())
+                current = rows[rows.count - 1]
+            }
+            if !current.items.isEmpty {
+                current.width += spacing
+            }
+            current.items.append((view, size))
+            current.width += size.width
+            current.height = max(current.height, size.height)
+            rows[rows.count - 1] = current
+        }
+        return rows
+    }
+}

--- a/Sources/BlockSitesApp/Views/SetupView.swift
+++ b/Sources/BlockSitesApp/Views/SetupView.swift
@@ -38,21 +38,7 @@ struct SetupView: View {
                     }
 
                     section("CUSTOM DOMAINS") {
-                        HStack(spacing: 6) {
-                            Text(">")
-                                .font(Theme.monoMD)
-                                .foregroundColor(Theme.phosphorDim)
-                            TextField("", text: $viewModel.customSitesText,
-                                      prompt: Text("example.com,another.com")
-                                        .foregroundColor(Theme.phosphorMuted))
-                                .textFieldStyle(.plain)
-                                .font(Theme.monoMD)
-                                .foregroundColor(Theme.phosphor)
-                                .tint(Theme.phosphor)
-                        }
-                        .padding(10)
-                        .background(Theme.surface)
-                        .overlay(Rectangle().stroke(Theme.phosphorMuted, lineWidth: 1))
+                        customDomainsBlock
                     }
 
                     section("DURATION") {
@@ -128,6 +114,65 @@ struct SetupView: View {
         .padding(10)
         .background(Theme.surface)
         .overlay(Rectangle().stroke(Theme.phosphorMuted, lineWidth: 1))
+    }
+
+    private var customDomainsBlock: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Text("$")
+                    .font(Theme.monoMD)
+                    .foregroundColor(Theme.phosphorDim)
+                TextField(
+                    "",
+                    text: $viewModel.pendingDomainInput,
+                    prompt: Text("type domain + enter (e.g. reddit.com)")
+                        .foregroundColor(Theme.phosphorMuted)
+                )
+                .textFieldStyle(.plain)
+                .font(Theme.monoMD)
+                .foregroundColor(Theme.phosphor)
+                .tint(Theme.phosphor)
+                .onSubmit {
+                    viewModel.commitPendingDomain()
+                }
+                Button(action: { viewModel.commitPendingDomain() }) {
+                    Text("ADD")
+                        .font(Theme.monoSM.weight(.bold))
+                        .foregroundColor(Theme.background)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(
+                            viewModel.pendingDomainInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                ? Theme.phosphorMuted : Theme.phosphor
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(viewModel.pendingDomainInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .padding(10)
+            .background(Theme.surface)
+            .overlay(Rectangle().stroke(Theme.phosphorMuted, lineWidth: 1))
+
+            if let err = viewModel.pendingDomainError {
+                Text("!! \(err)")
+                    .font(Theme.monoSM)
+                    .foregroundColor(Theme.amber)
+            }
+
+            if !viewModel.customDomains.isEmpty {
+                FlowLayout(spacing: 6, runSpacing: 6) {
+                    ForEach(viewModel.customDomains, id: \.self) { domain in
+                        DomainChip(domain: domain) {
+                            viewModel.removeCustomDomain(domain)
+                        }
+                    }
+                }
+            } else {
+                Text("// no custom domains added")
+                    .font(Theme.monoXS)
+                    .foregroundColor(Theme.phosphorMuted)
+            }
+        }
     }
 
     private var recoveryBanner: some View {


### PR DESCRIPTION
## Summary

Comma-separated input was cramped and gave no per-domain feedback. This PR ships a proper chip-based input inspired by tag editors.

### Changes
- **Input**: single TextField with prompt \`type domain + enter (e.g. reddit.com)\`. Pressing Enter (or clicking ADD) validates via \`DomainValidator.validateAndClean\` and appends to \`customDomains\`. Inline amber error line shows invalid / duplicate feedback.
- **Chip row**: each added domain renders as a phosphor-bordered \`DomainChip\` with an × remove button. Uses a new \`FlowLayout\` that wraps chips onto additional rows when they exceed the available width.
- **State model**: \`BlockViewModel\` swaps \`customSitesText: String\` for \`customDomains: [String]\` + \`pendingDomainInput\` + \`pendingDomainError\`. New methods: \`commitPendingDomain()\`, \`removeCustomDomain(_:)\`.
- **Empty state**: muted \`// no custom domains added\` comment when the list is empty.

### Why
Typing \`a.com,b.com,c.com\` in a single field gave no indication of which domains were valid until submit-time, and removing one required editing a comma-separated string. With chips the user sees validation immediately and can remove one with a single click.

## Test plan
- [x] \`swift build\` — clean
- [x] \`swift test\` — 144 tests passing (no regressions; the model logic changes don't affect Core)
- [ ] Manual: add valid domain, invalid domain (error), duplicate (error), remove chip, start block