### PR TITLE
feat: readable typography — JetBrains Mono web, SF Mono app, softer CRT

### DIFF
--- a/Sources/BlockSitesApp/Theme.swift
+++ b/Sources/BlockSitesApp/Theme.swift
@@ -1,35 +1,50 @@
 import SwiftUI
 
 enum Theme {
-    static let background = Color(red: 0.015, green: 0.025, blue: 0.015)
-    static let surface = Color(red: 0.03, green: 0.05, blue: 0.03)
-    static let phosphor = Color(red: 0.45, green: 1.0, blue: 0.55)
-    static let phosphorDim = Color(red: 0.45, green: 1.0, blue: 0.55).opacity(0.65)
-    static let phosphorMuted = Color(red: 0.45, green: 1.0, blue: 0.55).opacity(0.3)
-    static let phosphorGlow = Color(red: 0.45, green: 1.0, blue: 0.55).opacity(0.5)
-    static let amber = Color(red: 1.0, green: 0.75, blue: 0.2)
-    static let danger = Color(red: 1.0, green: 0.3, blue: 0.35)
-    static let dangerDim = Color(red: 1.0, green: 0.3, blue: 0.35).opacity(0.7)
+    // Desaturated phosphor palette: accent stays bright, body text is off-white
+    // with a subtle green cast so long reading doesn't burn the eye.
+    static let background = Color(red: 0.025, green: 0.035, blue: 0.025)
+    static let surface = Color(red: 0.045, green: 0.06, blue: 0.045)
 
+    /// Body text — readable off-white with a faint green hint.
+    static let foreground = Color(red: 0.88, green: 0.94, blue: 0.88)
+
+    /// Accent color for headers, buttons, timer, banner.
+    static let phosphor = Color(red: 0.55, green: 1.0, blue: 0.65)
+    /// Secondary accent; used for section headers and decorative chrome.
+    static let phosphorDim = Color(red: 0.65, green: 0.92, blue: 0.7)
+    /// Muted comments / hints / tertiary labels.
+    static let phosphorMuted = Color(red: 0.45, green: 0.65, blue: 0.5)
+    /// Glow color for shadows around the accent.
+    static let phosphorGlow = Color(red: 0.55, green: 1.0, blue: 0.65).opacity(0.45)
+
+    static let amber = Color(red: 1.0, green: 0.78, blue: 0.3)
+    static let danger = Color(red: 1.0, green: 0.35, blue: 0.4)
+    static let dangerDim = Color(red: 1.0, green: 0.35, blue: 0.4).opacity(0.7)
+
+    /// Uses SF Mono on macOS via the system monospaced design — wider and
+    /// more open than Menlo, so body copy is easier to read at small sizes.
     static func mono(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        Font.custom("Menlo", size: size).weight(weight)
+        Font.system(size: size, weight: weight, design: .monospaced)
     }
 
-    static let monoXS = mono(10)
-    static let monoSM = mono(11)
-    static let monoMD = mono(13)
-    static let monoLG = mono(16, weight: .bold)
+    static let monoXS = mono(11)
+    static let monoSM = mono(12)
+    static let monoMD = mono(14)
+    static let monoLG = mono(17, weight: .bold)
 }
 
 struct Scanlines: View {
     var body: some View {
-        GeometryReader { geo in
+        GeometryReader { _ in
             Canvas { ctx, size in
-                let lineHeight: CGFloat = 3
+                // Widen line pitch from 3px → 5px and lower opacity from 0.35 → 0.18
+                // so content behind the overlay stays readable.
+                let lineHeight: CGFloat = 5
                 var y: CGFloat = 0
                 while y < size.height {
                     let rect = CGRect(x: 0, y: y, width: size.width, height: 1)
-                    ctx.fill(Path(rect), with: .color(Color.black.opacity(0.35)))
+                    ctx.fill(Path(rect), with: .color(Color.black.opacity(0.18)))
                     y += lineHeight
                 }
             }
@@ -40,14 +55,14 @@ struct Scanlines: View {
 }
 
 struct CRTFlicker: View {
-    @State private var opacity: Double = 0.02
+    @State private var opacity: Double = 0.01
     var body: some View {
         Color.black
             .opacity(opacity)
             .allowsHitTesting(false)
             .onAppear {
-                withAnimation(.easeInOut(duration: 0.15).repeatForever(autoreverses: true)) {
-                    opacity = 0.06
+                withAnimation(.easeInOut(duration: 0.3).repeatForever(autoreverses: true)) {
+                    opacity = 0.03
                 }
             }
     }

--- a/Sources/BlockSitesApp/Views/SetupView.swift
+++ b/Sources/BlockSitesApp/Views/SetupView.swift
@@ -188,7 +188,7 @@ struct SetupView: View {
             }
             Text("/etc/hosts still contains block entries from a previous lockdown that was not cleaned up. Sites may still be unreachable. Run cleanup to restore normal access.")
                 .font(Theme.monoSM)
-                .foregroundColor(Theme.phosphorDim)
+                .foregroundColor(Theme.foreground)
                 .fixedSize(horizontal: false, vertical: true)
             Button(action: { viewModel.runRecoveryCleanup() }) {
                 HStack(spacing: 6) {

--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,12 @@
     <meta name="theme-color" content="#49ff7f" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap"
+    />
     <title>monkmode — strict mac blocker for deep work</title>
   </head>
   <body>

--- a/web/src/components/CRTOverlay.tsx
+++ b/web/src/components/CRTOverlay.tsx
@@ -5,7 +5,7 @@ export function Scanlines() {
       className="pointer-events-none fixed inset-0 z-50 mix-blend-multiply"
       style={{
         backgroundImage:
-          'repeating-linear-gradient(0deg, rgba(0,0,0,0.35) 0px, rgba(0,0,0,0.35) 1px, transparent 1px, transparent 3px)',
+          'repeating-linear-gradient(0deg, rgba(0,0,0,0.18) 0px, rgba(0,0,0,0.18) 1px, transparent 1px, transparent 5px)',
       }}
     />
   )
@@ -28,7 +28,7 @@ export function CRTFlicker() {
   return (
     <div
       aria-hidden
-      className="pointer-events-none fixed inset-0 z-50 animate-crt-flicker bg-black/5"
+      className="pointer-events-none fixed inset-0 z-50 animate-crt-flicker bg-black/[0.02]"
     />
   )
 }

--- a/web/src/components/Features.tsx
+++ b/web/src/components/Features.tsx
@@ -44,7 +44,7 @@ export function Features() {
               <span className="text-xs text-phosphor-muted">{f.id}.</span>
               <h3 className="text-sm font-bold tracking-wider text-phosphor">{f.title}</h3>
             </header>
-            <p className="mt-2 text-xs leading-relaxed text-phosphor-dim">{f.description}</p>
+            <p className="mt-2 text-[13px] leading-relaxed text-foreground">{f.description}</p>
           </article>
         ))}
       </div>

--- a/web/src/components/Hero.tsx
+++ b/web/src/components/Hero.tsx
@@ -74,7 +74,7 @@ export function Hero() {
         {BANNER}
       </pre>
 
-      <p className="mt-6 max-w-xl text-sm leading-relaxed text-phosphor-dim">
+      <p className="mt-6 max-w-xl text-sm leading-relaxed text-foreground">
         <span className="text-phosphor-muted">// </span>
         strict macOS website blocker for deep work. once the timer starts there
         is no abort — until it expires.

--- a/web/src/components/InstallSteps.tsx
+++ b/web/src/components/InstallSteps.tsx
@@ -33,7 +33,7 @@ export function InstallSteps() {
               <span className="text-phosphor-dim">$</span>
               <code className="text-phosphor">{s.prompt}</code>
             </div>
-            <p className="mt-1 pl-7 text-[11px] text-phosphor-muted sm:text-xs">
+            <p className="mt-1 pl-7 text-[12px] leading-relaxed text-foreground sm:text-[13px]">
               <span className="text-phosphor-muted">// </span>
               {s.output}
             </p>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -3,15 +3,15 @@
 @tailwind utilities;
 
 :root {
-  --background: 120 20% 2%;
-  --surface: 120 22% 5%;
-  --foreground: 130 80% 85%;
-  --phosphor: 130 100% 65%;
-  --phosphor-dim: 130 80% 55%;
-  --phosphor-muted: 130 40% 40%;
-  --amber: 38 95% 55%;
-  --danger: 355 85% 60%;
-  --border: 130 30% 20%;
+  --background: 120 12% 4%;
+  --surface: 120 10% 7%;
+  --foreground: 110 18% 90%;
+  --phosphor: 130 85% 70%;
+  --phosphor-dim: 130 40% 72%;
+  --phosphor-muted: 130 18% 50%;
+  --amber: 38 95% 60%;
+  --danger: 355 85% 65%;
+  --border: 130 15% 22%;
 }
 
 * {

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -22,7 +22,7 @@ export default {
         border: 'hsl(var(--border))',
       },
       fontFamily: {
-        mono: ['Menlo', 'Monaco', 'Courier New', 'monospace'],
+        mono: ['"JetBrains Mono"', 'Menlo', 'Monaco', 'Courier New', 'monospace'],
       },
       borderRadius: {
         none: '0',

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -36,8 +36,8 @@ export default {
       },
       keyframes: {
         'crt-flicker': {
-          '0%, 100%': { opacity: '0.02' },
-          '50%': { opacity: '0.08' },
+          '0%, 100%': { opacity: '0.3' },
+          '50%': { opacity: '0.9' },
         },
         blink: {
           '0%, 49%': { opacity: '1' },


### PR DESCRIPTION
## Summary

The neon phosphor + dense scanlines were burning eyes on anything longer than a label. This PR loosens that up without losing the terminal feel.

### Typography
- **Web**: JetBrains Mono 400/500/700 via Google Fonts. Wider letterforms and better hinting than Menlo.
- **App**: switch to \`Font.system(design: .monospaced)\` which is SF Mono on macOS — wider and rounder than Menlo, zero bundling overhead.
- Base size bumps: 10→11, 11→12, 13→14, 16→17.

### Color hierarchy
- **Body text** now uses an off-white \`foreground\` (high contrast, slight green hint).
- **Phosphor green** reserved for accents: banner, timer, headers, buttons, borders, selected states.
- **phosphor-dim** desaturated from 80%→40% sat so secondary labels don't scream.
- **phosphor-muted** mostly comment-style chrome; unchanged role.

### CRT softening
- Scanline pitch 3px → 5px, opacity 0.35 → 0.18 (both app and web).
- Flicker opacity halved.

## Test plan
- [x] \`swift build\` — clean
- [x] \`yarn build\` — clean
- [ ] Manual: compare before/after on landing page at localhost
- [ ] Manual: run app, verify body text is readable at normal distance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined color palette with updated background, surface, and accent shades
  * Integrated JetBrains Mono font for improved monospace typography
  * Adjusted CRT overlay effects (reduced scanline intensity and flicker)
  * Enhanced text readability across UI components with updated font sizes and new foreground color

<!-- end of auto-generated comment: release notes by coderabbit.ai -->