### PR TITLE
tweak: drop neon glow and desaturate phosphor

### DIFF
--- a/Sources/BlockSitesApp/Theme.swift
+++ b/Sources/BlockSitesApp/Theme.swift
@@ -9,14 +9,15 @@ enum Theme {
     /// Body text — readable off-white with a faint green hint.
     static let foreground = Color(red: 0.88, green: 0.94, blue: 0.88)
 
-    /// Accent color for headers, buttons, timer, banner.
-    static let phosphor = Color(red: 0.55, green: 1.0, blue: 0.65)
+    /// Accent color for headers, buttons, timer, banner. Desaturated to
+    /// avoid the neon glare of saturated green on a dark background.
+    static let phosphor = Color(red: 0.6, green: 0.9, blue: 0.68)
     /// Secondary accent; used for section headers and decorative chrome.
-    static let phosphorDim = Color(red: 0.65, green: 0.92, blue: 0.7)
+    static let phosphorDim = Color(red: 0.65, green: 0.85, blue: 0.72)
     /// Muted comments / hints / tertiary labels.
-    static let phosphorMuted = Color(red: 0.45, green: 0.65, blue: 0.5)
-    /// Glow color for shadows around the accent.
-    static let phosphorGlow = Color(red: 0.55, green: 1.0, blue: 0.65).opacity(0.45)
+    static let phosphorMuted = Color(red: 0.5, green: 0.65, blue: 0.55)
+    /// Kept for API compatibility but effectively off; glows removed.
+    static let phosphorGlow = Color.clear
 
     static let amber = Color(red: 1.0, green: 0.78, blue: 0.3)
     static let danger = Color(red: 1.0, green: 0.35, blue: 0.4)

--- a/Sources/BlockSitesApp/Views/ActiveBlockView.swift
+++ b/Sources/BlockSitesApp/Views/ActiveBlockView.swift
@@ -30,7 +30,6 @@ struct ActiveBlockView: View {
                                 endPoint: .bottom
                             )
                         )
-                        .shadow(color: Theme.danger.opacity(0.6), radius: 3)
                         .lineSpacing(-2)
                         .fixedSize(horizontal: true, vertical: true)
 
@@ -55,8 +54,6 @@ struct ActiveBlockView: View {
                         Text(formatCountdown(viewModel.remainingSeconds))
                             .font(Theme.mono(68, weight: .bold))
                             .foregroundColor(Theme.phosphor)
-                            .shadow(color: Theme.phosphorGlow, radius: 10)
-                            .shadow(color: Theme.phosphorGlow, radius: 4)
                             .minimumScaleFactor(0.5)
                             .lineLimit(1)
                             .frame(maxWidth: .infinity)
@@ -126,7 +123,6 @@ struct ActiveBlockView: View {
             Text(str)
                 .font(Theme.mono(14, weight: .bold))
                 .foregroundColor(Theme.phosphor)
-                .shadow(color: Theme.phosphorGlow, radius: 3)
                 .lineLimit(1)
         }
         .frame(height: 20)
@@ -176,7 +172,6 @@ struct BlinkDot: View {
     var body: some View {
         Text("●")
             .foregroundColor(Theme.danger)
-            .shadow(color: Theme.danger.opacity(0.8), radius: 4)
             .opacity(on ? 1 : 0.3)
             .onAppear {
                 withAnimation(.easeInOut(duration: 0.7).repeatForever()) {

--- a/Sources/BlockSitesApp/Views/SetupView.swift
+++ b/Sources/BlockSitesApp/Views/SetupView.swift
@@ -93,7 +93,6 @@ struct SetupView: View {
                     endPoint: .bottom
                 )
             )
-            .shadow(color: Theme.phosphorGlow, radius: 3)
             .lineSpacing(-2)
             .fixedSize(horizontal: true, vertical: true)
     }

--- a/web/src/components/Hero.tsx
+++ b/web/src/components/Hero.tsx
@@ -62,13 +62,10 @@ export function Hero() {
         aria-label="MONKMODE"
         className="mt-6 overflow-x-auto text-[6px] leading-[7px] sm:text-[9px] sm:leading-[10px]"
         style={{
-          color: 'hsl(var(--phosphor))',
-          textShadow: '0 0 6px hsl(var(--phosphor) / 0.55)',
           background:
-            'linear-gradient(180deg, hsl(130 100% 85%) 0%, hsl(130 100% 65%) 35%, hsl(160 90% 55%) 75%, hsl(165 70% 35%) 100%)',
+            'linear-gradient(180deg, hsl(120 40% 82%) 0%, hsl(130 55% 70%) 40%, hsl(150 45% 58%) 80%, hsl(160 40% 42%) 100%)',
           WebkitBackgroundClip: 'text',
           WebkitTextFillColor: 'transparent',
-          filter: 'drop-shadow(0 0 6px hsl(var(--phosphor) / 0.45))',
         }}
       >
         {BANNER}
@@ -85,14 +82,14 @@ export function Hero() {
           href={release.downloadUrl}
           target="_blank"
           rel="noreferrer"
-          className="group inline-flex items-center gap-2 bg-phosphor px-5 py-3 text-sm font-bold text-background shadow-phosphor transition-colors hover:bg-phosphor-dim"
+          className="group inline-flex items-center gap-2 bg-phosphor px-5 py-3 text-sm font-bold text-background transition-colors hover:bg-phosphor-dim"
         >
           <span>{'>>'}</span>
           <span>DOWNLOAD.dmg</span>
           <span>{'<<'}</span>
         </a>
         <div className="inline-flex items-center gap-2 border border-phosphor-muted px-3 py-3 text-xs text-phosphor-dim">
-          <span className="inline-block h-2 w-2 bg-phosphor shadow-phosphorSoft" />
+          <span className="inline-block h-2 w-2 bg-phosphor" />
           {release.loading ? 'checking release...' : `latest: ${release.version}`}
         </div>
       </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -3,15 +3,15 @@
 @tailwind utilities;
 
 :root {
-  --background: 120 12% 4%;
-  --surface: 120 10% 7%;
-  --foreground: 110 18% 90%;
-  --phosphor: 130 85% 70%;
-  --phosphor-dim: 130 40% 72%;
-  --phosphor-muted: 130 18% 50%;
-  --amber: 38 95% 60%;
-  --danger: 355 85% 65%;
-  --border: 130 15% 22%;
+  --background: 120 10% 5%;
+  --surface: 120 8% 8%;
+  --foreground: 110 15% 90%;
+  --phosphor: 130 45% 68%;
+  --phosphor-dim: 130 25% 72%;
+  --phosphor-muted: 130 12% 50%;
+  --amber: 38 75% 62%;
+  --danger: 355 55% 62%;
+  --border: 130 12% 22%;
 }
 
 * {


### PR DESCRIPTION
Removes shadow()/textShadow/drop-shadow glows and lowers phosphor saturation (app 100%→90%, web 85%→45%) so body text no longer burns. Banner gradient swapped to muted greens.