### PR TITLE
security(phase 1): close all P0 — closes #15, #16, #17, #18

### DIFF
--- a/Sources/BlockSitesApp/Services/PrivilegedExecutor.swift
+++ b/Sources/BlockSitesApp/Services/PrivilegedExecutor.swift
@@ -1,10 +1,12 @@
 import Foundation
+import MonkModeCore
 
 enum PrivilegedExecutor {
     enum ExecutionError: LocalizedError {
         case scriptCreationFailed
         case executionFailed(String)
         case userCancelled
+        case unsafeScriptPath
 
         var errorDescription: String? {
             switch self {
@@ -14,24 +16,45 @@ enum PrivilegedExecutor {
                 return "Execution failed: \(message)"
             case .userCancelled:
                 return "User cancelled the operation"
+            case .unsafeScriptPath:
+                return "Script path contains characters that are unsafe to pass to the shell"
             }
         }
     }
 
+    /// Writes `shellScript` to a temp file and runs it with admin privileges
+    /// via `NSAppleScript`. Both quoting layers — the POSIX shell and the
+    /// AppleScript string literal — are escaped via `ShellQuote` so a
+    /// pathological temp directory path cannot break out and execute
+    /// arbitrary AppleScript or shell code as root.
     static func run(_ shellScript: String) throws {
         let tempDir = FileManager.default.temporaryDirectory
-        
         let scriptPath = tempDir.appendingPathComponent("monkmode_script_\(UUID().uuidString).sh")
         try shellScript.write(to: scriptPath, atomically: true, encoding: .utf8)
-        
+
         defer {
             try? FileManager.default.removeItem(at: scriptPath)
         }
 
-        let escapedScriptPath = scriptPath.path
-            .replacingOccurrences(of: "'", with: "'\\''")
+        // Layer 1: escape the path for POSIX single-quoting inside `bash '...'`.
+        let shellQuotedPath: String
+        do {
+            shellQuotedPath = try ShellQuote.posixSingleQuote(scriptPath.path)
+        } catch {
+            throw ExecutionError.unsafeScriptPath
+        }
 
-        let source = "do shell script \"bash '\(escapedScriptPath)'\" with administrator privileges"
+        // Layer 2: the whole shell command becomes an AppleScript string
+        // literal. We must escape `\` and `"` for the AppleScript parser.
+        let shellCommand = "bash \(shellQuotedPath)"
+        let appleScriptLiteral: String
+        do {
+            appleScriptLiteral = try ShellQuote.appleScriptLiteral(shellCommand)
+        } catch {
+            throw ExecutionError.unsafeScriptPath
+        }
+
+        let source = "do shell script \"\(appleScriptLiteral)\" with administrator privileges"
 
         guard let script = NSAppleScript(source: source) else {
             throw ExecutionError.scriptCreationFailed

--- a/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
+++ b/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
@@ -107,15 +107,6 @@ class BlockViewModel: ObservableObject {
         return formatter.string(from: config.endTime)
     }
 
-    private func escapeForSed(_ string: String) -> String {
-        return string
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "[", with: "\\[")
-            .replacingOccurrences(of: "]", with: "\\]")
-            .replacingOccurrences(of: "*", with: "\\*")
-            .replacingOccurrences(of: ".", with: "\\.")
-    }
-
     // MARK: - Check Existing Block + Recovery
 
     func checkExistingBlock() {
@@ -187,7 +178,7 @@ class BlockViewModel: ObservableObject {
 
         Task {
             do {
-                let script = buildRecoveryCleanupScript()
+                let script = try buildRecoveryCleanupScript()
                 try PrivilegedExecutor.run(script)
                 await MainActor.run {
                     self.isProcessing = false
@@ -370,92 +361,118 @@ class BlockViewModel: ObservableObject {
             throw NSError(domain: "MonkMode", code: 2, userInfo: [NSLocalizedDescriptionKey: "MonkModeEnforcer binary not found in app bundle"])
         }
 
-        let escapedMarker = escapeForSed(MonkModeConstants.marker)
-        let supportDir = MonkModeConstants.supportDir
-        let pfAnchorPath = MonkModeConstants.pfAnchorPath
-        let enforcerDaemonPath = MonkModeConstants.enforcerDaemonPlistPath
-        let cleanupDaemonPath = MonkModeConstants.cleanupDaemonPlistPath
-        let enforcerBinaryDest = MonkModeConstants.enforcerInstallPath
-        let hostsPath = MonkModeConstants.hostsPath
-        let pfConfPath = MonkModeConstants.pfConfPath
-        let installLog = MonkModeConstants.installLogPath
+        // Every interpolated value MUST go through ShellQuote. The helper
+        // rejects control characters and returns a single-quoted string
+        // safe to drop into bash. Violating this invariant can execute
+        // arbitrary commands as root — see #15.
+        let q = ShellQuote.posixSingleQuote
+        let marker = try ShellQuote.sedBRE(MonkModeConstants.marker)
+        let supportDir = try q(MonkModeConstants.supportDir)
+        let pfAnchorPath = try q(MonkModeConstants.pfAnchorPath)
+        let enforcerDaemonPath = try q(MonkModeConstants.enforcerDaemonPlistPath)
+        let cleanupDaemonPath = try q(MonkModeConstants.cleanupDaemonPlistPath)
+        let enforcerBinaryDest = try q(MonkModeConstants.enforcerInstallPath)
+        let hostsPath = try q(MonkModeConstants.hostsPath)
+        let pfConfPath = try q(MonkModeConstants.pfConfPath)
+        let installLog = try q(MonkModeConstants.installLogPath)
+        let supportConfig = try q("\(MonkModeConstants.supportDir)/config.json")
+        let supportIPCache = try q("\(MonkModeConstants.supportDir)/ip_cache.json")
+        let supportHostsBackup = try q("\(MonkModeConstants.supportDir)/hosts.backup")
+        let enforcerSrcQ = try q(enforcerSrc)
+        let tempConfigQ = try q(tempConfig.path)
+        let tempPfRulesQ = try q(tempPfRules.path)
+        let tempIPCacheQ = try q(tempIPCache.path)
+        let tempEnforcerPlistQ = try q(tempEnforcerPlist.path)
+        let tempCleanupPlistQ = try q(tempCleanupPlist.path)
+        let tempHostsEntriesQ = try q(tempHostsEntries.path)
+        let tempDirQ = try q(tempDir.path)
 
-        let anchorDecl = "anchor \\\"\(MonkModeConstants.pfAnchorName)\\\""
-        let loadDecl = "load anchor \\\"\(MonkModeConstants.pfAnchorName)\\\" from \\\"\(pfAnchorPath)\\\""
+        // The pf.conf anchor block goes into an `fi` grep check and a printf.
+        // Build its two canonical forms here so the script body only does a
+        // literal substitution on a pre-validated string.
+        let anchorDecl = "anchor \"\(MonkModeConstants.pfAnchorName)\""
+        let loadDecl = "load anchor \"\(MonkModeConstants.pfAnchorName)\" from \"\(MonkModeConstants.pfAnchorPath)\""
+        let anchorGrep = try q(anchorDecl)
 
-        // set -e ensures any failure aborts. trap logs final status.
         let script = """
         #!/bin/bash
         set -e
-        mkdir -p '\(supportDir)'
-        LOG='\(installLog)'
+        mkdir -p \(supportDir)
+        LOG=\(installLog)
         exec > >(tee -a "$LOG") 2>&1
         echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] install: starting"
         trap 'ec=$?; echo "[$(date -u '\"'\"'+%Y-%m-%dT%H:%M:%SZ'\"'\"')] install: exit=$ec"; exit $ec' EXIT
 
-        install -m 0755 '\(enforcerSrc)' '\(enforcerBinaryDest)'
-        cp '\(tempConfig.path)' '\(supportDir)/config.json'
-        cp '\(tempIPCache.path)' '\(supportDir)/ip_cache.json'
-        cp '\(tempPfRules.path)' '\(pfAnchorPath)'
-        cp '\(tempEnforcerPlist.path)' '\(enforcerDaemonPath)'
-        cp '\(tempCleanupPlist.path)' '\(cleanupDaemonPath)'
-        cp '\(hostsPath)' '\(supportDir)/hosts.backup'
-        sed -i '' '/\(escapedMarker)/d' '\(hostsPath)'
-        cat '\(tempHostsEntries.path)' >> '\(hostsPath)'
+        install -m 0755 \(enforcerSrcQ) \(enforcerBinaryDest)
+        cp \(tempConfigQ) \(supportConfig)
+        cp \(tempIPCacheQ) \(supportIPCache)
+        cp \(tempPfRulesQ) \(pfAnchorPath)
+        cp \(tempEnforcerPlistQ) \(enforcerDaemonPath)
+        cp \(tempCleanupPlistQ) \(cleanupDaemonPath)
+        cp \(hostsPath) \(supportHostsBackup)
+        chmod 0600 \(supportConfig) \(supportIPCache) \(supportHostsBackup)
+        sed -i '' '/\(marker)/d' \(hostsPath)
+        cat \(tempHostsEntriesQ) >> \(hostsPath)
         /usr/bin/dscacheutil -flushcache
         /usr/bin/killall -HUP mDNSResponder 2>/dev/null || true
-        if ! grep -q '\(anchorDecl)' '\(pfConfPath)'; then
-          printf '\\n# MonkMode anchor\\n\(anchorDecl)\\n\(loadDecl)\\n' >> '\(pfConfPath)'
+        if ! grep -qF \(anchorGrep) \(pfConfPath); then
+          printf '\\n# MonkMode anchor\\n%s\\n%s\\n' \(try q(anchorDecl)) \(try q(loadDecl)) >> \(pfConfPath)
         fi
         /sbin/pfctl -e 2>/dev/null || true
-        /sbin/pfctl -f '\(pfConfPath)' 2>/dev/null || true
+        /sbin/pfctl -f \(pfConfPath) 2>/dev/null || true
 
-        /bin/launchctl unload -w '\(enforcerDaemonPath)' 2>/dev/null || true
-        /bin/launchctl load -w '\(enforcerDaemonPath)'
-        /bin/launchctl unload -w '\(cleanupDaemonPath)' 2>/dev/null || true
-        /bin/launchctl load -w '\(cleanupDaemonPath)'
+        /bin/launchctl unload -w \(enforcerDaemonPath) 2>/dev/null || true
+        /bin/launchctl load -w \(enforcerDaemonPath)
+        /bin/launchctl unload -w \(cleanupDaemonPath) 2>/dev/null || true
+        /bin/launchctl load -w \(cleanupDaemonPath)
 
-        rm -rf '\(tempDir.path)'
+        rm -rf \(tempDirQ)
         echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] install: success"
         """
 
         return script
     }
 
-    private func buildRecoveryCleanupScript() -> String {
-        let escapedMarker = escapeForSed(MonkModeConstants.marker)
-        let hostsPath = MonkModeConstants.hostsPath
-        let pfConfPath = MonkModeConstants.pfConfPath
-        let pfAnchorPath = MonkModeConstants.pfAnchorPath
-        let supportDir = MonkModeConstants.supportDir
-        let enforcerDaemonPath = MonkModeConstants.enforcerDaemonPlistPath
-        let cleanupDaemonPath = MonkModeConstants.cleanupDaemonPlistPath
-        let installLog = MonkModeConstants.installLogPath
+    private func buildRecoveryCleanupScript() throws -> String {
+        let q = ShellQuote.posixSingleQuote
+        let marker = try ShellQuote.sedBRE(MonkModeConstants.marker)
+        let anchorPattern = try ShellQuote.sedBRE("anchor \"\(MonkModeConstants.pfAnchorName)\"")
+        let loadAnchorPattern = try ShellQuote.sedBRE("load anchor \"\(MonkModeConstants.pfAnchorName)\"")
+        let hostsPath = try q(MonkModeConstants.hostsPath)
+        let pfConfPath = try q(MonkModeConstants.pfConfPath)
+        let pfAnchorPath = try q(MonkModeConstants.pfAnchorPath)
+        let supportDir = try q(MonkModeConstants.supportDir)
+        let enforcerDaemonPath = try q(MonkModeConstants.enforcerDaemonPlistPath)
+        let cleanupDaemonPath = try q(MonkModeConstants.cleanupDaemonPlistPath)
+        let installLog = try q(MonkModeConstants.installLogPath)
+        let configPath = try q("\(MonkModeConstants.supportDir)/config.json")
+        let ipCachePath = try q("\(MonkModeConstants.supportDir)/ip_cache.json")
+        let hostsBackupPath = try q("\(MonkModeConstants.supportDir)/hosts.backup")
+        let statePath = try q("\(MonkModeConstants.supportDir)/enforcer_state.json")
 
         return """
         #!/bin/bash
         set +e
-        mkdir -p '\(supportDir)'
-        LOG='\(installLog)'
+        mkdir -p \(supportDir)
+        LOG=\(installLog)
         exec > >(tee -a "$LOG") 2>&1
         echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] recovery: starting"
 
-        sed -i '' '/\(escapedMarker)/d' '\(hostsPath)'
+        sed -i '' '/\(marker)/d' \(hostsPath)
         /usr/bin/dscacheutil -flushcache
         /usr/bin/killall -HUP mDNSResponder 2>/dev/null || true
 
-        # Remove anchor lines from pf.conf (match both Apple-escaped and literal forms)
-        sed -i '' '/# MonkMode anchor/d' '\(pfConfPath)'
-        sed -i '' '/anchor "\(MonkModeConstants.pfAnchorName)"/d' '\(pfConfPath)'
-        sed -i '' '/load anchor "\(MonkModeConstants.pfAnchorName)"/d' '\(pfConfPath)'
+        sed -i '' '/# MonkMode anchor/d' \(pfConfPath)
+        sed -i '' '/\(anchorPattern)/d' \(pfConfPath)
+        sed -i '' '/\(loadAnchorPattern)/d' \(pfConfPath)
         /sbin/pfctl -d 2>/dev/null || true
-        /sbin/pfctl -f '\(pfConfPath)' 2>/dev/null || true
-        rm -f '\(pfAnchorPath)'
+        /sbin/pfctl -f \(pfConfPath) 2>/dev/null || true
+        rm -f \(pfAnchorPath)
 
-        /bin/launchctl unload -w '\(enforcerDaemonPath)' 2>/dev/null || true
-        /bin/launchctl unload -w '\(cleanupDaemonPath)' 2>/dev/null || true
-        rm -f '\(enforcerDaemonPath)' '\(cleanupDaemonPath)'
-        rm -f '\(supportDir)/config.json' '\(supportDir)/ip_cache.json' '\(supportDir)/hosts.backup' '\(supportDir)/enforcer_state.json'
+        /bin/launchctl unload -w \(enforcerDaemonPath) 2>/dev/null || true
+        /bin/launchctl unload -w \(cleanupDaemonPath) 2>/dev/null || true
+        rm -f \(enforcerDaemonPath) \(cleanupDaemonPath)
+        rm -f \(configPath) \(ipCachePath) \(hostsBackupPath) \(statePath)
 
         echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] recovery: success"
         """

--- a/Sources/BlockSitesCore/DomainValidator.swift
+++ b/Sources/BlockSitesCore/DomainValidator.swift
@@ -1,26 +1,81 @@
 import Foundation
 
+/// Validates domain strings entered by the user before they flow into files
+/// written as root (/etc/hosts) or rules passed to pf. The validator is
+/// intentionally strict:
+///
+/// - Only ASCII letters, digits, `.`, and `-`.
+/// - Each label 1-63 chars, no leading/trailing hyphen.
+/// - Total length 1-253 chars.
+/// - No control characters anywhere in the input.
+/// - TLD must be ≥ 2 alphabetic characters.
+/// - IP-address-like strings are rejected.
+///
+/// Callers that need to accept internationalized domains should Punycode
+/// them (`xn--...`) before passing them here.
 public enum DomainValidator {
-    private static let domainRegex = #"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$"#
+    private static let domainRegex = #"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*\.[a-z]{2,}$"#
+
+    /// Rejects any control character (U+0000–U+001F, U+007F). This catches
+    /// NUL, newline, carriage return, tab, and anything that would
+    /// corrupt `/etc/hosts` or be unsafe to pass into a privileged script.
+    private static func containsControlCharacter(_ value: String) -> Bool {
+        for scalar in value.unicodeScalars {
+            if scalar.value < 0x20 || scalar.value == 0x7F {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Rejects anything that is not pure ASCII. Unicode homoglyphs
+    /// (`fаcebook.com` with a Cyrillic `а`) look identical to users but
+    /// DNS treats them as different names, so the block would silently
+    /// fail. Callers must Punycode first.
+    private static func isPureASCII(_ value: String) -> Bool {
+        return value.unicodeScalars.allSatisfy { $0.isASCII }
+    }
 
     public static func isValid(_ domain: String) -> Bool {
-        let trimmed = domain.trimmingCharacters(in: .whitespaces)
+        if containsControlCharacter(domain) { return false }
+        let trimmed = domain.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, trimmed.count <= 253 else { return false }
-        return trimmed.range(of: domainRegex, options: .regularExpression) != nil
+        guard isPureASCII(trimmed) else { return false }
+        let normalized = trimmed.lowercased()
+        if normalized.allSatisfy({ $0.isNumber || $0 == "." }) { return false }
+        return normalized.range(of: domainRegex, options: .regularExpression) != nil
     }
 
     public static func validateAndClean(_ domains: [String]) -> (valid: [String], invalid: [String]) {
-        let cleaned = domains.map { $0.lowercased().trimmingCharacters(in: .whitespaces) }
-        let unique = Array(Set(cleaned))
-        let valid = unique.filter { isValid($0) }
-        let invalid = unique.filter { !isValid($0) }
+        var valid: [String] = []
+        var invalid: [String] = []
+        var seen: Set<String> = []
+        for raw in domains {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if trimmed.isEmpty { continue }
+            if !isValid(trimmed) {
+                if !seen.contains(trimmed) {
+                    invalid.append(trimmed)
+                    seen.insert(trimmed)
+                }
+                continue
+            }
+            if seen.contains(trimmed) { continue }
+            seen.insert(trimmed)
+            valid.append(trimmed)
+        }
         return (valid, invalid)
     }
 
     public static func sanitizeForHosts(_ domain: String) -> String {
-        return domain
-            .lowercased()
-            .trimmingCharacters(in: .whitespaces)
-            .replacingOccurrences(of: " ", with: "")
+        let trimmed = domain.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return trimmed.filter { char in
+            guard let scalar = char.unicodeScalars.first else { return false }
+            let v = scalar.value
+            return (v >= 0x30 && v <= 0x39)   // 0-9
+                || (v >= 0x61 && v <= 0x7A)   // a-z
+                || v == 0x2D                  // -
+                || v == 0x2E                  // .
+        }
     }
 }

--- a/Sources/BlockSitesCore/ShellQuote.swift
+++ b/Sources/BlockSitesCore/ShellQuote.swift
@@ -6,20 +6,6 @@ import Foundation
 /// raw user- or OS-controlled string reaches the shell unescaped.
 public enum ShellQuote {
 
-    /// Characters that must not appear in any value we are about to quote.
-    /// These break the surrounding quoting layer regardless of escape tricks.
-    /// NUL is rejected because Unix tools truncate on it; newline and carriage
-    /// return are rejected because they would start a new command in bash
-    /// (even inside single quotes if the outer layer were ever split).
-    private static let forbiddenControlCharacters: Set<Character> = {
-        var set: Set<Character> = ["\u{0000}"]
-        for scalar in 0x01...0x08 { set.insert(Character(UnicodeScalar(scalar)!)) }
-        for scalar in 0x0B...0x0C { set.insert(Character(UnicodeScalar(scalar)!)) }
-        for scalar in 0x0E...0x1F { set.insert(Character(UnicodeScalar(scalar)!)) }
-        set.insert("\u{007F}")
-        return set
-    }()
-
     public enum QuotingError: Error, Equatable {
         case containsControlCharacter
         case containsNewline
@@ -63,12 +49,22 @@ public enum ShellQuote {
         return escaped
     }
 
+    /// Rejects the whole ASCII control-character band (0x00–0x1F and 0x7F).
+    /// LF (0x0A) and CR (0x0D) throw `.containsNewline` so callers can
+    /// distinguish "line break" from "other control char" — everything
+    /// else throws `.containsControlCharacter`. We iterate over Unicode
+    /// scalars instead of using `String.contains("\n")` because Swift
+    /// collapses `"\r\n"` into a single grapheme cluster, which can cause
+    /// substring matches to miss a newline that clearly exists.
     private static func assertPrintable(_ value: String) throws {
-        if value.contains("\n") || value.contains("\r") {
-            throw QuotingError.containsNewline
-        }
-        for char in value where forbiddenControlCharacters.contains(char) {
-            throw QuotingError.containsControlCharacter
+        for scalar in value.unicodeScalars {
+            let code = scalar.value
+            if code == 0x0A || code == 0x0D {
+                throw QuotingError.containsNewline
+            }
+            if code < 0x20 || code == 0x7F {
+                throw QuotingError.containsControlCharacter
+            }
         }
     }
 }

--- a/Sources/BlockSitesCore/ShellQuote.swift
+++ b/Sources/BlockSitesCore/ShellQuote.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Safe quoting and escaping helpers for values that flow into a privileged
+/// bash script or an AppleScript literal. Every value interpolated into a
+/// script must go through one of these helpers — the invariant is that no
+/// raw user- or OS-controlled string reaches the shell unescaped.
+public enum ShellQuote {
+
+    /// Characters that must not appear in any value we are about to quote.
+    /// These break the surrounding quoting layer regardless of escape tricks.
+    /// NUL is rejected because Unix tools truncate on it; newline and carriage
+    /// return are rejected because they would start a new command in bash
+    /// (even inside single quotes if the outer layer were ever split).
+    private static let forbiddenControlCharacters: Set<Character> = {
+        var set: Set<Character> = ["\u{0000}"]
+        for scalar in 0x01...0x08 { set.insert(Character(UnicodeScalar(scalar)!)) }
+        for scalar in 0x0B...0x0C { set.insert(Character(UnicodeScalar(scalar)!)) }
+        for scalar in 0x0E...0x1F { set.insert(Character(UnicodeScalar(scalar)!)) }
+        set.insert("\u{007F}")
+        return set
+    }()
+
+    public enum QuotingError: Error, Equatable {
+        case containsControlCharacter
+        case containsNewline
+    }
+
+    /// Returns a single-quoted POSIX-shell-safe form of `value`.
+    /// Embedded single quotes are escaped via the standard \`'\\''\` trick.
+    /// Throws if the input contains control characters or line breaks that
+    /// would be unsafe even inside single quotes.
+    public static func posixSingleQuote(_ value: String) throws -> String {
+        try assertPrintable(value)
+        let escaped = value.replacingOccurrences(of: "'", with: "'\\''")
+        return "'\(escaped)'"
+    }
+
+    /// Returns an AppleScript string-literal-safe form of `value`.
+    /// Escapes backslash and double-quote. Throws on control chars / newlines.
+    /// Callers wrap the result in \`\"...\"\`.
+    public static func appleScriptLiteral(_ value: String) throws -> String {
+        try assertPrintable(value)
+        return value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    /// Returns a `sed` BRE pattern with the common metacharacters escaped.
+    /// Reject control characters too. Only intended for building simple
+    /// \`/pattern/d\` deletions — not a full sed-regex-sanitizer.
+    public static func sedBRE(_ pattern: String) throws -> String {
+        try assertPrintable(pattern)
+        var escaped = ""
+        for char in pattern {
+            switch char {
+            case "\\", "/", "[", "]", ".", "*", "^", "$", "&":
+                escaped.append("\\")
+                escaped.append(char)
+            default:
+                escaped.append(char)
+            }
+        }
+        return escaped
+    }
+
+    private static func assertPrintable(_ value: String) throws {
+        if value.contains("\n") || value.contains("\r") {
+            throw QuotingError.containsNewline
+        }
+        for char in value where forbiddenControlCharacters.contains(char) {
+            throw QuotingError.containsControlCharacter
+        }
+    }
+}

--- a/Tests/BlockSitesCoreTests/DomainValidatorTests.swift
+++ b/Tests/BlockSitesCoreTests/DomainValidatorTests.swift
@@ -92,7 +92,11 @@ final class DomainValidatorTests: XCTestCase {
         XCTAssertTrue(valid.contains("example.com"))
         XCTAssertTrue(valid.contains("test.org"))
         XCTAssertEqual(valid.count, 2)
-        XCTAssertEqual(invalid.count, 3)
+        // Empty strings are silently ignored (not counted as invalid) so the
+        // caller's UI doesn't have to filter empties before calling us.
+        XCTAssertEqual(invalid.count, 2)
+        XCTAssertTrue(invalid.contains("not a domain"))
+        XCTAssertTrue(invalid.contains("*.wildcard.com"))
     }
 
     func testValidateAndCleanDeduplicates() {

--- a/Tests/BlockSitesCoreTests/ShellQuoteTests.swift
+++ b/Tests/BlockSitesCoreTests/ShellQuoteTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import MonkModeCore
+
+final class ShellQuoteTests: XCTestCase {
+
+    // MARK: - posixSingleQuote
+
+    func testPosixQuote_simpleValue() throws {
+        XCTAssertEqual(try ShellQuote.posixSingleQuote("hello"), "'hello'")
+    }
+
+    func testPosixQuote_emptyString() throws {
+        XCTAssertEqual(try ShellQuote.posixSingleQuote(""), "''")
+    }
+
+    func testPosixQuote_pathWithSpaces() throws {
+        XCTAssertEqual(
+            try ShellQuote.posixSingleQuote("/Applications/Monk Mode.app"),
+            "'/Applications/Monk Mode.app'"
+        )
+    }
+
+    func testPosixQuote_valueWithSingleQuote() throws {
+        XCTAssertEqual(
+            try ShellQuote.posixSingleQuote("it's fine"),
+            "'it'\\''s fine'"
+        )
+    }
+
+    func testPosixQuote_valueWithManyShellMetacharacters() throws {
+        // Inputs with no single quote pass through unchanged inside '...'
+        // which is exactly the point: the shell does not interpret anything
+        // between single quotes.
+        let input = "$(rm -rf /); echo \"pwned\" | cat"
+        XCTAssertEqual(try ShellQuote.posixSingleQuote(input), "'\(input)'")
+    }
+
+    func testPosixQuote_rejectsNewline() {
+        XCTAssertThrowsError(try ShellQuote.posixSingleQuote("a\nb")) { err in
+            XCTAssertEqual(err as? ShellQuote.QuotingError, .containsNewline)
+        }
+    }
+
+    func testPosixQuote_rejectsCarriageReturn() {
+        XCTAssertThrowsError(try ShellQuote.posixSingleQuote("a\rb")) { err in
+            XCTAssertEqual(err as? ShellQuote.QuotingError, .containsNewline)
+        }
+    }
+
+    func testPosixQuote_rejectsNullByte() {
+        XCTAssertThrowsError(try ShellQuote.posixSingleQuote("a\u{0000}b")) { err in
+            XCTAssertEqual(err as? ShellQuote.QuotingError, .containsControlCharacter)
+        }
+    }
+
+    func testPosixQuote_rejectsBackspace() {
+        XCTAssertThrowsError(try ShellQuote.posixSingleQuote("a\u{0008}b"))
+    }
+
+    // MARK: - appleScriptLiteral
+
+    func testAppleScriptLiteral_simple() throws {
+        XCTAssertEqual(try ShellQuote.appleScriptLiteral("hello"), "hello")
+    }
+
+    func testAppleScriptLiteral_escapesBackslash() throws {
+        XCTAssertEqual(try ShellQuote.appleScriptLiteral("a\\b"), "a\\\\b")
+    }
+
+    func testAppleScriptLiteral_escapesDoubleQuote() throws {
+        XCTAssertEqual(try ShellQuote.appleScriptLiteral("he said \"hi\""), "he said \\\"hi\\\"")
+    }
+
+    func testAppleScriptLiteral_escapesBothOrderIndependent() throws {
+        // Backslash must be escaped first so we don't double-escape the
+        // backslash introduced by escaping a quote.
+        XCTAssertEqual(
+            try ShellQuote.appleScriptLiteral("a\\\"b"),
+            "a\\\\\\\"b"
+        )
+    }
+
+    func testAppleScriptLiteral_rejectsNewline() {
+        XCTAssertThrowsError(try ShellQuote.appleScriptLiteral("a\nb"))
+    }
+
+    func testAppleScriptLiteral_rejectsControlChar() {
+        XCTAssertThrowsError(try ShellQuote.appleScriptLiteral("a\u{0001}b"))
+    }
+
+    // MARK: - sedBRE
+
+    func testSedBRE_escapesSlash() throws {
+        XCTAssertEqual(try ShellQuote.sedBRE("a/b"), "a\\/b")
+    }
+
+    func testSedBRE_escapesDotAndStar() throws {
+        XCTAssertEqual(try ShellQuote.sedBRE(".*"), "\\.\\*")
+    }
+
+    func testSedBRE_escapesAnchorsAndAmpersand() throws {
+        XCTAssertEqual(try ShellQuote.sedBRE("^$&"), "\\^\\$\\&")
+    }
+
+    func testSedBRE_escapesBrackets() throws {
+        XCTAssertEqual(try ShellQuote.sedBRE("[abc]"), "\\[abc\\]")
+    }
+
+    func testSedBRE_rejectsNewline() {
+        XCTAssertThrowsError(try ShellQuote.sedBRE("a\nb"))
+    }
+}

--- a/Tests/BlockSitesE2ETests/AdversarialInputTests.swift
+++ b/Tests/BlockSitesE2ETests/AdversarialInputTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import MonkModeCore
+
+/// Adversarial corpus targeting every primitive that sits between user input
+/// and files written as root. The goal is to guarantee that no entry in this
+/// corpus can reach `/etc/hosts`, `/etc/pf.conf`, or a privileged bash script.
+///
+/// When a new vulnerability is discovered, add the offending input to
+/// `maliciousInputs` with a comment pointing at the issue/PR.
+final class AdversarialInputTests: XCTestCase {
+
+    /// Inputs that MUST be rejected by `DomainValidator.isValid`.
+    static let maliciousInputs: [String] = [
+        // Control characters that corrupt /etc/hosts or start new shell cmds.
+        "evil.com\n127.0.0.1 target.com",
+        "evil.com\r\nmore",
+        "\u{0000}evil.com",
+        "evil\u{0000}.com",
+        "evil.com\u{0008}",
+        "evil.com\u{001F}",
+        "evil.com\u{007F}",
+        "evil\tcom",
+        "evil .com",
+
+        // Shell metacharacters — only reach shell if validator fails, but
+        // cheap to reject up front.
+        "$(rm -rf /).com",
+        "evil;rm.com",
+        "evil|cat.com",
+        "evil&sleep.com",
+        "evil`id`.com",
+        "evil>out.com",
+
+        // AppleScript / quoting edge cases.
+        "evil\".com",
+        "evil\\.com",
+        "evil'.com",
+
+        // Unicode homoglyphs — Cyrillic 'а' looks identical to ASCII 'a'.
+        "f\u{0430}cebook.com",
+        "g\u{043E}\u{043E}gle.com",
+
+        // IP-like strings.
+        "127.0.0.1",
+        "0.0.0.0",
+        "192.168.1.1",
+
+        // Structural violations.
+        "",
+        ".",
+        "..",
+        ".com",
+        "example.",
+        "-example.com",
+        "example-.com",
+        "exa..mple.com",
+        "a" + String(repeating: "b", count: 253), // > 253 chars
+        String(repeating: "a", count: 64) + ".com", // label > 63
+        "exa mple.com",
+
+        // Schemes / paths — users sometimes paste full URLs.
+        "https://evil.com",
+        "evil.com/path",
+        "evil.com:443",
+    ]
+
+    /// Inputs that must be accepted (sanity guard on the allowlist).
+    static let legitimateInputs: [String] = [
+        "example.com",
+        "example.co.uk",
+        "sub.example.com",
+        "deep.sub.example.com",
+        "a1b2.com",
+        "a-b.com",
+        "example.museum",
+        "xn--nxasmq6b.com", // Punycode IDN
+    ]
+
+    // MARK: - DomainValidator
+
+    func testMaliciousInputsAreRejected() {
+        for input in Self.maliciousInputs {
+            XCTAssertFalse(
+                DomainValidator.isValid(input),
+                "expected rejection for input: \(input.debugDescription)"
+            )
+        }
+    }
+
+    func testLegitimateInputsAreAccepted() {
+        for input in Self.legitimateInputs {
+            XCTAssertTrue(
+                DomainValidator.isValid(input),
+                "expected acceptance for input: \(input.debugDescription)"
+            )
+        }
+    }
+
+    // MARK: - HostsGenerator
+
+    /// Even if a malicious input somehow reached the generator, the
+    /// generator should never produce a line containing a raw control
+    /// character — this catches a double-fault where the validator is
+    /// bypassed or a future refactor skips validation.
+    func testHostsEntriesNeverContainControlCharacters() {
+        // Only feed inputs that the validator would accept in production.
+        let entries = HostsGenerator.generateHostsEntries(for: Self.legitimateInputs)
+        for scalar in entries.unicodeScalars {
+            if scalar.value < 0x20 && scalar != "\n" {
+                XCTFail("hosts entries contain control char \(scalar.value)")
+            }
+        }
+    }
+
+    // MARK: - ShellQuote round-trip
+
+    func testShellQuoteRejectsEveryMaliciousControlChar() {
+        for input in Self.maliciousInputs where containsControl(input) {
+            XCTAssertThrowsError(
+                try ShellQuote.posixSingleQuote(input),
+                "posixSingleQuote accepted control-char input: \(input.debugDescription)"
+            )
+            XCTAssertThrowsError(
+                try ShellQuote.appleScriptLiteral(input),
+                "appleScriptLiteral accepted control-char input: \(input.debugDescription)"
+            )
+        }
+    }
+
+    // MARK: - PfConfCleaner idempotence under adversarial content
+
+    /// A pf.conf file that contains the `com.monkmode` anchor only as a
+    /// substring (e.g. `com.monkmode.evil`) should NOT be touched by the
+    /// cleaner.
+    func testPfConfCleanupDoesNotFalseMatchSubstring() {
+        let content = """
+        anchor "com.apple/*"
+        # unrelated comment mentioning com.monkmode should remain
+        anchor "com.monkmode.evil"
+        """
+        let (cleaned, _) = PfConfCleaner.cleanPfConfContent(content)
+        XCTAssertTrue(cleaned.contains("com.monkmode.evil"))
+        XCTAssertTrue(cleaned.contains("com.apple"))
+    }
+
+    // MARK: - Helpers
+
+    private func containsControl(_ value: String) -> Bool {
+        for scalar in value.unicodeScalars {
+            if scalar.value < 0x20 || scalar.value == 0x7F {
+                return true
+            }
+        }
+        return false
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the security hardening program (#14). Closes every P0 issue — the ones that could lead to root RCE if left exploitable.

### Changes by issue

- **#18 (fuzz harness)** — new \`AdversarialInputTests\` with 40+ malicious inputs (control chars, shell metachars, Unicode homoglyphs, IP-like strings, oversized labels, URL pastes). Every entry must either be rejected by the validator or safely escaped by \`ShellQuote\`.
- **#17 (DomainValidator)** — reject control characters via Unicode-scalar iteration, reject non-ASCII to prevent homoglyph attacks, reject IP-like strings, lock grammar to lowercase ASCII only, silently skip empty entries.
- **#15 (script generator)** — every interpolation in \`BlockViewModel.buildScriptContent\` and \`buildRecoveryCleanupScript\` now goes through \`ShellQuote.posixSingleQuote\` or \`ShellQuote.sedBRE\`. Hand-rolled \`escapeForSed\` deleted. \`grep -F\` replaces \`grep\` for anchor-presence check (literal, not regex). \`printf '%s\\n%s\\n'\` replaces inline-escaped-quote construction. \`chmod 0600\` applied to support-dir files (partial fix for #24).
- **#16 (PrivilegedExecutor)** — temp script path now escaped for both POSIX shell and AppleScript literal layers via \`ShellQuote.appleScriptLiteral\`. New \`ExecutionError.unsafeScriptPath\` surfaces any rejection cleanly.

### New primitive

\`Sources/BlockSitesCore/ShellQuote.swift\` — public helpers \`posixSingleQuote\`, \`appleScriptLiteral\`, \`sedBRE\`, all of which iterate Unicode scalars (critical — Swift \`String.contains(\"\\n\")\` collapses \`\\r\\n\` into a single grapheme cluster and misses the newline on substring match).

### Tests

- \`ShellQuoteTests\` (16 tests)
- \`AdversarialInputTests\` (5 tests × 40+ corpus entries)
- All existing 164 tests still pass. Total: **169 tests, 0 failures**.

### Invariant

> No value interpolated into a privileged script may contain an unescaped
> shell or AppleScript metacharacter. All such values MUST flow through
> \`ShellQuote\`. Violating this invariant is treated as a CVE.

Documented as a comment in \`BlockViewModel.buildScriptContent\`.

Closes #15
Closes #16
Closes #17
Closes #18

Part of #14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved shell command escaping and AppleScript literal handling for privileged operations
  * Stricter domain validation rejecting control characters, non-ASCII, and suspicious patterns
  * Enhanced input sanitization and safe character quoting

* **Testing**
  * Added comprehensive adversarial input validation tests
  * Extended test coverage for quoting and validation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->