### PR TITLE
security(phase 2): SECURITY.md, THREAT_MODEL.md, CODEOWNERS — closes #21, #29

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,34 @@
+# CODEOWNERS — requires owner approval for changes to privileged paths.
+# See docs/THREAT_MODEL.md for why these files are sensitive.
+# Syntax: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Privileged script generators — any change here can affect the bash
+# script that runs as root via NSAppleScript.
+/Sources/BlockSitesApp/Services/PrivilegedExecutor.swift  @gilbertsahumada
+/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift    @gilbertsahumada
+
+# Input sanitizers — the validator and quoter sitting between user input
+# and privileged files.
+/Sources/BlockSitesCore/DomainValidator.swift             @gilbertsahumada
+/Sources/BlockSitesCore/ShellQuote.swift                  @gilbertsahumada
+/Sources/BlockSitesCore/HostsGenerator.swift              @gilbertsahumada
+/Sources/BlockSitesCore/PfConfCleaner.swift               @gilbertsahumada
+/Sources/BlockSitesCore/DaemonPlistBuilder.swift          @gilbertsahumada
+/Sources/BlockSitesCore/Constants.swift                   @gilbertsahumada
+
+# The entire enforcer target — runs as root on a 60s interval.
+/Sources/BlockSitesEnforcer/                              @gilbertsahumada
+
+# Adversarial test corpus — removing a test here weakens the safety net.
+/Tests/BlockSitesE2ETests/AdversarialInputTests.swift     @gilbertsahumada
+/Tests/BlockSitesCoreTests/ShellQuoteTests.swift          @gilbertsahumada
+
+# Release pipeline — compromise here ships a bad binary to every user.
+/scripts/build_dmg.sh                                     @gilbertsahumada
+/scripts/smoke_test.sh                                    @gilbertsahumada
+/.github/workflows/                                       @gilbertsahumada
+/.github/CODEOWNERS                                       @gilbertsahumada
+
+# Security documents — live alongside the code they describe.
+/SECURITY.md                                              @gilbertsahumada
+/docs/THREAT_MODEL.md                                     @gilbertsahumada

--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,13 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 
-# Ignore root markdown files except README and CONTRIBUTING
+# Ignore root markdown files except the ones we publish
 /*.md
 !README.md
 !CONTRIBUTING.md
 !RELEASE.md
 !TROUBLESHOOTING.md
+!SECURITY.md
 
 # worktrees
 .claude/worktrees   

--- a/README.md
+++ b/README.md
@@ -117,10 +117,23 @@ If sites remain blocked after the timer expires, see [TROUBLESHOOTING.md](TROUBL
 
 ## Security
 
-- Input validation for custom domains (prevents injection)
-- Script injection prevention via temp file execution
-- Secure shell escaping for sed commands
-- Hash-based change detection to minimize system impact
+MonkMode runs a LaunchDaemon as root. Security reports are handled privately —
+please **do not** open a public issue for a vulnerability. See
+[SECURITY.md](SECURITY.md) for the disclosure policy and
+[docs/THREAT_MODEL.md](docs/THREAT_MODEL.md) for the adversary model,
+trust boundaries, and current mitigations.
+
+In-code safeguards:
+
+- `DomainValidator` rejects control characters, non-ASCII (Unicode
+  homoglyphs), IP-like strings, and structural violations.
+- `ShellQuote` quotes every value interpolated into the privileged bash
+  script and escapes both the POSIX shell layer and the AppleScript
+  string literal layer. Violations fail the build via the
+  `AdversarialInputTests` corpus.
+- Enforcer re-applies the block every 60 seconds and a secondary
+  LaunchDaemon fires at exact `endTime` as redundancy.
+- `CODEOWNERS` guards every privileged code path and the release pipeline.
 
 ## Warning
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,92 @@
+# Security Policy
+
+MonkMode requests root privileges on the user's Mac to modify `/etc/hosts`,
+`/etc/pf.conf`, and `/Library/LaunchDaemons`. A defect in the application or
+the release pipeline can therefore escalate to root code execution on user
+machines. We take reports seriously.
+
+## Supported versions
+
+Only the latest tagged release on the `main` branch receives security fixes.
+Older DMGs in the GitHub releases archive are left in place for historical
+reference but should be considered end-of-life on release of their successor.
+
+| Version | Supported |
+|---------|-----------|
+| Latest release on `main` | ✅ |
+| Any prior release | ❌ |
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for a security report.** Instead, please
+use one of the private channels below:
+
+1. **Preferred — GitHub Security Advisories**
+   Visit [Security → Advisories → Report a vulnerability](https://github.com/gilbertsahumada/self-control/security/advisories/new)
+   on this repository. GitHub routes the report directly to the maintainers
+   with no intermediate party.
+2. **Email** — `gilbertsahumada@gmail.com`. Use subject line
+   `[MonkMode security] <short description>`. If you want an encrypted
+   channel, include your PGP key in the message and the maintainer will
+   reply in kind.
+
+Please include, if you have them:
+
+- A short description of the issue and why it matters.
+- A proof-of-concept or minimal reproduction.
+- The version (git commit or release tag) you tested against.
+- Your name or alias if you'd like credit in the advisory.
+
+## Response SLA
+
+The maintainer is a single individual. Best-effort targets:
+
+- **Acknowledgement:** within 72 hours of report.
+- **Initial assessment and severity classification:** within 7 days.
+- **Fix and coordinated disclosure:** within 30 days for high severity,
+  90 days for medium, no strict window for low. Public disclosure via a
+  GitHub Security Advisory and release notes.
+
+If you haven't heard back within a week, email a nudge with `[nudge]` in the
+subject; the original report may have been missed.
+
+## Safe harbor
+
+Good-faith research is welcome. You will not be pursued for:
+
+- Probing the application in a disposable VM or on hardware you own.
+- Reverse-engineering the DMG, the enforcer binary, or the daemon plists.
+- Testing against a fresh install where you are the only user.
+
+Please refrain from:
+
+- Running attacks against a system you do not own.
+- Exfiltrating or modifying another user's data.
+- Denial-of-service testing against public infrastructure (GitHub Pages,
+  release assets).
+
+## Disclosure practice
+
+After a fix ships in a signed, notarized release we publish the advisory on
+the repository's Security tab with a CVE when appropriate. Reporters are
+credited unless they request otherwise.
+
+## Out of scope
+
+The following are documented trade-offs, not vulnerabilities:
+
+- The user can physically remove the Mac's hard drive and edit `/etc/hosts`
+  from another boot. MonkMode does not claim to survive physical access.
+- Users with existing root access can of course defeat the block. The
+  threat model is a user committing to a block while retaining normal
+  account-level privileges.
+- An attacker who already has root on the target Mac can tamper with
+  any file MonkMode writes. We are not a defense against pre-existing
+  root compromise.
+
+## Living documents
+
+This policy lives in the repository alongside [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md)
+and the security tracker in [issue #14](https://github.com/gilbertsahumada/self-control/issues/14).
+Both are updated as the project evolves; pull requests that materially
+change security posture must update them.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,177 @@
+# MonkMode Threat Model
+
+Last reviewed: 2026-04-23. Maintainer: @gilbertsahumada.
+
+This document describes the assets MonkMode protects, the adversaries it
+considers, the trust boundaries in its architecture, and the mitigations
+currently in place. It is a living document: any pull request that changes
+privileges, file layout, the privileged-script pipeline, or the release
+process must update the relevant section.
+
+## 1. Assets
+
+| Asset | What it is | Why it matters |
+|-------|------------|----------------|
+| Root shell on the user's Mac | The LaunchDaemon runs as root; any RCE through the app becomes a root RCE | Loss = full control of the machine |
+| Integrity of `/etc/hosts` and `/etc/pf.conf` | Files written during a block | Corruption breaks normal network access for the user |
+| The user's commitment | The "you can't abort the block" promise is the product | If the block is bypassable without effort, the product has no value |
+| User trust in the DMG | Open-source binary distributed via GitHub releases | If a tampered DMG ever ships, every downstream user is at risk |
+| Maintainer credentials | GitHub account, signing certificate, PGP key | Compromise allows shipping a backdoor at scale |
+
+## 2. Adversaries
+
+| Adversary | Capability | Worst-case outcome |
+|-----------|------------|--------------------|
+| **A1: The user themselves at a moment of weakness** | Runs the app, types into the UI, has their own account credentials | Would like to bypass the timer; app must resist casual tampering |
+| **A2: A second unprivileged user on the same Mac** | Has their own home directory, cannot sudo | Read user's block list, force cleanup, corrupt daemon state |
+| **A3: Network MITM on DMG download** | Can intercept TLS-terminated traffic (compromised CA, ISP injection) | Ship a tampered DMG that runs as root once the user opens it |
+| **A4: Compromised maintainer account or signing cert** | Pushes code to `main`, signs releases | Distribute a backdoored release to every user |
+| **A5: Compromised upstream dependency** | npm package, Google Fonts CDN, Xcode/Swift toolchain | Inject payload into the landing page or, worst, into the app build |
+| **A6: Hostile app input** | User pastes a crafted domain string | Attempt shell / sed / AppleScript injection through `BlockViewModel` into the root-run script |
+
+Out of scope:
+
+- Physical access to the Mac (the user can boot into recovery and edit files
+  directly — MonkMode does not claim to survive offline tampering).
+- Pre-existing root compromise on the target Mac (we cannot protect files we
+  write if the attacker already has the capability to modify them).
+
+## 3. Trust boundaries
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ User-space (unprivileged)                                    │
+│  - SwiftUI app (MonkMode.app)                                │
+│  - BlockViewModel: builds privileged scripts (#15 invariant) │
+│  - PrivilegedExecutor: passes scripts to NSAppleScript (#16) │
+├─────────────── NSAppleScript administrator privileges ───────┤
+│ Root execution context                                       │
+│  - bash -c <generated script>                                │
+│  - writes /etc/hosts, /etc/pf.conf, /etc/pf.anchors          │
+│  - writes /Library/Application Support/MonkMode (mode 0600)  │
+│  - writes /Library/LaunchDaemons/com.monkmode.*.plist        │
+│  - installs /usr/local/bin/monkmode-enforcer                 │
+├─────────────── LaunchDaemon runtime ─────────────────────────┤
+│ Root, detached, runs every 60s + one-shot at endTime         │
+│  - MonkModeEnforcer re-applies or tears down the block       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Every crossing is enforced by an explicit mechanism:
+
+- **User-space → root (NSAppleScript):** the AppleScript password dialog.
+  MonkMode never stores the password.
+- **Generated script → root bash:** every value interpolated into the
+  script must pass through `ShellQuote` (see #15 invariant below).
+- **LaunchDaemon → root bash:** plist `ProgramArguments` points at a single
+  binary we own at `/usr/local/bin/monkmode-enforcer`.
+
+### The #15 invariant
+
+> No value interpolated into the privileged bash script may contain an
+> unescaped shell, sed, or AppleScript metacharacter. All such values MUST
+> be routed through `ShellQuote.posixSingleQuote`, `ShellQuote.sedBRE`, or
+> `ShellQuote.appleScriptLiteral`. A violation is treated as a CVE.
+
+Enforced by code review plus the `AdversarialInputTests` corpus. New
+mitigations land as new corpus entries.
+
+## 4. Mitigations in place
+
+### Against A1 (user in a moment of weakness)
+
+- No "cancel block" control in the UI.
+- Enforcer daemon runs every 60s and re-writes `/etc/hosts` / `pf` from the
+  persisted config, reverting any manual edits.
+- A secondary LaunchDaemon fires at the exact `endTime` as a redundancy
+  against primary enforcer failure.
+
+**Known gap:** the user can edit `/etc/hosts` as root between enforcer
+ticks. We do not attempt to be tamper-proof against the user's own root.
+
+### Against A2 (another unprivileged user on the same Mac)
+
+- `/Library/Application Support/MonkMode/` config files are created with
+  mode `0600` and owned by root (see #24 for the permissions audit task).
+- The privileged script validates inputs (#17 `DomainValidator`) before
+  writing them, so one user cannot craft input that leaks via the log.
+
+**Known gap:** an audit of every file we create for mode and ownership is
+tracked in #24 and will be verified by the smoke test.
+
+### Against A3 (MITM on DMG download)
+
+- GitHub serves the DMG over HTTPS with certificate pinning on the
+  browser side.
+- We are moving from ad-hoc signing to Developer ID signing + Apple
+  notarization (tracked in #19). Once notarized, macOS Gatekeeper will
+  refuse to run a tampered DMG without requiring `xattr -cr`.
+- SHA256 checksums published alongside each release (tracked in #20).
+
+**Known gap:** today the install docs tell users to run `xattr -cr`
+which disables Gatekeeper. Until #19 ships, a compromised download
+still executes. This is the #1 priority after Phase 1.
+
+### Against A4 (compromised maintainer)
+
+- Branch protection on `main` requires a reviewed pull request plus
+  passing status checks, disallows force-push, and requires signed
+  commits (see #21).
+- `CODEOWNERS` requires an owner approval for PRs that touch the
+  privileged script generator, the enforcer, or release workflows.
+- Releases are moving to a reproducible CI-only workflow triggered by
+  a signed tag; the certificate lives in GitHub secrets, not on any
+  maintainer laptop (#23).
+- Two-factor authentication with a hardware key is mandatory on the
+  maintainer's GitHub account.
+
+**Known gap:** GitHub Secrets are fetched by any workflow the maintainer
+authorizes — a malicious workflow on a feature branch could read them
+if branch protection is ever weakened. Review requirements on
+`.github/workflows/` close this gap.
+
+### Against A5 (compromised upstream dependency)
+
+- Swift targets depend on `Foundation`, `SwiftUI`, `AppKit`, and
+  `XCTest` only. No third-party Swift packages.
+- Web targets have a small React + Vite footprint; `yarn audit --level high`
+  gates CI (#27).
+- JetBrains Mono currently loads from Google Fonts CDN; self-hosted
+  copy tracked in #28 for fewer third-party fetches at runtime.
+- Renovate / Dependabot bumps dependencies weekly with a security label.
+
+### Against A6 (hostile app input)
+
+- `DomainValidator` rejects control characters, non-ASCII, IP-like
+  strings, structural violations, URLs, paths, and shell metacharacters.
+- `ShellQuote` rejects any control character in any value before quoting.
+- `AdversarialInputTests` enforces this on every build with a corpus of
+  40+ attack strings.
+
+## 5. Residual risk
+
+Risks we accept today because mitigation cost is not yet justified or is
+deferred to a later phase:
+
+1. **Ad-hoc code signing until #19 closes.** A tampered DMG runs if the
+   user follows the documented `xattr -cr` step. Priority P1.
+2. **No signed DoH blocklist updates (#26).** A DoH provider added after
+   the last release is not blocked. Low exploit value (only helps the
+   user bypass themselves); not a privilege-escalation risk.
+3. **Fonts via Google Fonts CDN (#28).** Leaks visitor IP per page load.
+   Landing page only, no data or privilege.
+4. **Enforcer log is not redacted by default (#25).** Domain names the
+   user chose to block are written to `/Library/Application Support/
+   MonkMode/enforcer.log`. Not world-readable once #24 closes.
+
+## 6. Change control
+
+This document must be updated before merging any PR that:
+
+- Adds or removes a trust boundary.
+- Changes the set of files written by the privileged script.
+- Changes the enforcer's execution schedule or privileges.
+- Modifies the release pipeline, signing keys, or branch protection.
+- Introduces a new third-party dependency.
+
+Reviewers should treat an out-of-date threat model as a blocking comment.


### PR DESCRIPTION
## Summary

Phase 2 of the security program (#14). Lands the policy and guardrail documents before the signing/release work in Phase 3.

### Changes

- **\`SECURITY.md\`** — disclosure policy, reporting channels (GH Security Advisories + maintainer email), 72 h acknowledgement SLA, safe harbor clause, supported-versions matrix, and explicit out-of-scope cases (physical access, pre-existing root compromise).
- **\`docs/THREAT_MODEL.md\`** — assets, six adversaries with worst-case outcomes, trust-boundary diagram, mitigations grouped by adversary, residual risks with linked issues, change-control rules for future PRs.
- **\`.github/CODEOWNERS\`** — every privileged path (script generators, input sanitizers, enforcer target, release scripts, workflows, adversarial tests) now requires owner approval.
- **README** — points users/researchers at SECURITY.md and the threat model instead of the old bullet list.
- **\`.gitignore\`** — allow \`SECURITY.md\` at repo root.

Branch protection on \`main\` (require PR + review + status checks, disallow force push, dismiss stale reviews) will be applied via \`gh api\` after this PR merges, since the setting applies to the branch not a file in the tree.

Closes #21
Closes #29

Part of #14.