### PR TITLE
security(phase 4): uninstaller, permissions, log hygiene — closes #22, #24, #25

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,6 +71,26 @@ After a fix ships in a signed, notarized release we publish the advisory on
 the repository's Security tab with a CVE when appropriate. Reporters are
 credited unless they request otherwise.
 
+## Logging and data
+
+MonkMode writes three files under `/Library/Application Support/MonkMode/`:
+
+| File | Mode | Content | Redaction |
+|------|------|---------|-----------|
+| `config.json` | 0644 (root-owned, world-readable) | start/end time, blocked sites | No — block list is chosen by the user |
+| `ip_cache.json` | 0644 | resolved IPs per blocked domain | No — public DNS data |
+| `hosts.backup` | 0600 (root-only) | snapshot of `/etc/hosts` before the block | Not accessible to other users |
+| `install.log` | 0640 | timing + exit codes of the privileged install | No domain names |
+| `enforcer.log` | 0644 | actions taken by the 60 s daemon | Domain-shaped tokens replaced with `<domain>`; rotates at 1 MB |
+
+The enforcer never sends anything off the machine. No telemetry, no
+crash reporting, no remote update beacon. If a future release needs any
+network activity beyond the one-time DoH-blocklist refresh (#26), it
+will be documented here and gated behind an opt-in.
+
+Run the enforcer with `MONKMODE_LOG_VERBOSE=1` in its environment to
+disable redaction when debugging.
+
 ## Out of scope
 
 The following are documented trade-offs, not vulnerabilities:

--- a/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
+++ b/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
@@ -470,7 +470,13 @@ class BlockViewModel: ObservableObject {
         cp \(tempCleanupPlistQ) \(cleanupDaemonPath)
         cp \(hostsPath) \(supportHostsBackup)
         chown root:wheel \(supportConfig) \(supportIPCache) \(supportHostsBackup)
-        chmod 0600 \(supportConfig) \(supportIPCache) \(supportHostsBackup)
+        # config.json + ip_cache.json are world-readable (0644) so the
+        # unprivileged app can check block state. They are only WRITABLE
+        # by root, which is what protects against a second local user
+        # shortening the timer. hosts.backup stays 0600 because it mirrors
+        # the user's full /etc/hosts and may contain private entries.
+        chmod 0644 \(supportConfig) \(supportIPCache)
+        chmod 0600 \(supportHostsBackup)
         sed -i '' '/\(marker)/d' \(hostsPath)
         cat \(tempHostsEntriesQ) >> \(hostsPath)
         /usr/bin/dscacheutil -flushcache

--- a/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
+++ b/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
@@ -451,7 +451,11 @@ class BlockViewModel: ObservableObject {
         #!/bin/bash
         set -e
         mkdir -p \(supportDir)
+        chown root:wheel \(supportDir)
+        chmod 0755 \(supportDir)
         LOG=\(installLog)
+        touch "$LOG"
+        chmod 0640 "$LOG"
         exec > >(tee -a "$LOG") 2>&1
         echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] install: starting"
         trap 'ec=$?; echo "[$(date -u '\"'\"'+%Y-%m-%dT%H:%M:%SZ'\"'\"')] install: exit=$ec"; exit $ec' EXIT
@@ -465,6 +469,7 @@ class BlockViewModel: ObservableObject {
         cp \(tempEnforcerPlistQ) \(enforcerDaemonPath)
         cp \(tempCleanupPlistQ) \(cleanupDaemonPath)
         cp \(hostsPath) \(supportHostsBackup)
+        chown root:wheel \(supportConfig) \(supportIPCache) \(supportHostsBackup)
         chmod 0600 \(supportConfig) \(supportIPCache) \(supportHostsBackup)
         sed -i '' '/\(marker)/d' \(hostsPath)
         cat \(tempHostsEntriesQ) >> \(hostsPath)

--- a/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
+++ b/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
@@ -170,6 +170,50 @@ class BlockViewModel: ObservableObject {
         return hosts.contains(MonkModeConstants.marker)
     }
 
+    /// Full uninstall: runs the bundled `uninstall.sh` via privileged
+    /// execution. Removes every system modification MonkMode installs
+    /// (daemons, enforcer binary, support dir, hosts entries, pf anchor).
+    /// Leaves /Applications/MonkMode.app in place — user drags to Trash.
+    func runUninstall() {
+        let scriptPath = Bundle.main.url(forResource: "uninstall", withExtension: "sh")?.path
+            ?? Bundle.main.bundleURL.appendingPathComponent("Contents/Resources/uninstall.sh").path
+
+        guard FileManager.default.fileExists(atPath: scriptPath) else {
+            errorMessage = "uninstall.sh not found at \(scriptPath)"
+            return
+        }
+
+        isProcessing = true
+        errorMessage = nil
+
+        Task {
+            do {
+                let quoted = try ShellQuote.posixSingleQuote(scriptPath)
+                let wrapper = "#!/bin/bash\nbash \(quoted)\n"
+                try PrivilegedExecutor.run(wrapper)
+                await MainActor.run {
+                    self.isProcessing = false
+                    self.isBlocking = false
+                    self.config = nil
+                    self.needsRecoveryCleanup = false
+                    self.isWaitingForDaemonCleanup = false
+                    self.errorMessage = "MonkMode was uninstalled. Drag the app to the Trash to complete."
+                }
+            } catch let error as PrivilegedExecutor.ExecutionError {
+                await MainActor.run {
+                    self.isProcessing = false
+                    if case .userCancelled = error { return }
+                    self.errorMessage = error.localizedDescription
+                }
+            } catch {
+                await MainActor.run {
+                    self.isProcessing = false
+                    self.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
     /// Triggers a privileged cleanup of leftover /etc/hosts + pf state.
     /// Used when the enforcer daemon failed to clean up after expiry.
     func runRecoveryCleanup() {

--- a/Sources/BlockSitesApp/Views/SetupView.swift
+++ b/Sources/BlockSitesApp/Views/SetupView.swift
@@ -60,6 +60,8 @@ struct SetupView: View {
                     Text("// WARNING: LOCKDOWN CANNOT BE ABORTED ONCE INITIATED")
                         .font(Theme.monoXS)
                         .foregroundColor(Theme.amber.opacity(0.7))
+
+                    uninstallRow
                 }
                 .padding(24)
             }
@@ -95,6 +97,28 @@ struct SetupView: View {
             )
             .lineSpacing(-2)
             .fixedSize(horizontal: true, vertical: true)
+    }
+
+    @State private var showUninstallConfirm = false
+
+    private var uninstallRow: some View {
+        HStack {
+            Spacer()
+            Button(action: { showUninstallConfirm = true }) {
+                Text("uninstall monkmode")
+                    .font(Theme.monoXS)
+                    .foregroundColor(Theme.phosphorMuted)
+                    .underline()
+            }
+            .buttonStyle(.plain)
+            .disabled(viewModel.isProcessing || viewModel.isBlocking)
+        }
+        .alert("[ CONFIRM UNINSTALL ]", isPresented: $showUninstallConfirm) {
+            Button("CANCEL", role: .cancel) {}
+            Button("UNINSTALL", role: .destructive) { viewModel.runUninstall() }
+        } message: {
+            Text("Removes the enforcer daemon, hosts entries, pf anchor, and /Library/Application Support/MonkMode. Drag the app to the Trash afterwards to finish.")
+        }
     }
 
     private var waitingBanner: some View {

--- a/Sources/BlockSitesEnforcer/main.swift
+++ b/Sources/BlockSitesEnforcer/main.swift
@@ -6,9 +6,43 @@ struct EnforcerState: Codable {
     var firstRunDone: Bool
 }
 
+/// Rotate the enforcer log when it crosses this size. One tick of the
+/// enforcer writes at most a few dozen bytes, so at 60s cadence a
+/// 1 MB cap still holds ~months of history.
+private let enforcerLogMaxBytes: Int = 1_000_000
+
+private func rotateLogIfNeeded() {
+    let path = MonkModeConstants.enforcerLogPath
+    guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+          let size = attrs[.size] as? Int,
+          size >= enforcerLogMaxBytes else {
+        return
+    }
+    let rotated = path + ".1"
+    try? FileManager.default.removeItem(atPath: rotated)
+    try? FileManager.default.moveItem(atPath: path, toPath: rotated)
+}
+
+/// Strip user-chosen domains from log messages so another local user
+/// (or an attacker who later gains read access to the log) cannot
+/// reconstruct the block list from the tail. A debug build with
+/// `MONKMODE_LOG_VERBOSE=1` in the environment preserves raw content.
+private func redact(_ message: String) -> String {
+    if ProcessInfo.processInfo.environment["MONKMODE_LOG_VERBOSE"] == "1" {
+        return message
+    }
+    let pattern = #"([a-z0-9][a-z0-9-]{0,61}\.)+[a-z]{2,}"#
+    guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+        return message
+    }
+    let range = NSRange(message.startIndex..., in: message)
+    return regex.stringByReplacingMatches(in: message, range: range, withTemplate: "<domain>")
+}
+
 func enforcerLog(_ message: String) {
+    rotateLogIfNeeded()
     let timestamp = ISO8601DateFormatter().string(from: Date())
-    let entry = "[\(timestamp)] \(message)\n"
+    let entry = "[\(timestamp)] \(redact(message))\n"
     if let handle = FileHandle(forWritingAtPath: MonkModeConstants.enforcerLogPath) {
         handle.seekToEndOfFile()
         handle.write(entry.data(using: .utf8) ?? Data())

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -77,10 +77,12 @@ codesign --verify --verbose "dist/$APP_NAME"
 
 echo "App bundle created at dist/$APP_NAME"
 
-# Create DMG — move .app to a temp staging dir so the DMG only contains the .app
+# Create DMG — stage the .app + the uninstaller so the DMG is self-contained.
 echo "Creating DMG..."
 STAGING_DIR=$(mktemp -d)
 cp -R "dist/$APP_NAME" "$STAGING_DIR/"
+cp "scripts/uninstall.sh" "$STAGING_DIR/uninstall.sh"
+chmod +x "$STAGING_DIR/uninstall.sh"
 hdiutil create -volname "MonkMode" -srcfolder "$STAGING_DIR" -ov -format UDZO "dist/MonkMode-${APP_VERSION}.dmg"
 rm -rf "$STAGING_DIR"
 

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -30,6 +30,11 @@ if [ -f "assets/AppIcon.icns" ]; then
   echo "App icon copied to Resources"
 fi
 
+# Ship the uninstall script inside the app so the in-app uninstall flow
+# can locate it via Bundle.main.
+cp "scripts/uninstall.sh" "$RESOURCES_PATH/uninstall.sh"
+chmod +x "$RESOURCES_PATH/uninstall.sh"
+
 # Create Info.plist
 cat > "$CONTENTS_PATH/Info.plist" << EOF
 <?xml version="1.0" encoding="UTF-8"?>

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -94,7 +94,30 @@ else
     info "No PF anchor file at $PF_ANCHOR"
 fi
 
-# 6. Launch daemon plists
+# 6. Support dir permissions (see #24)
+SUPPORT_DIR="/Library/Application Support/MonkMode"
+check_mode() {
+    local path="$1"
+    local expected="$2"
+    if [[ ! -e "$path" ]]; then
+        return 0
+    fi
+    local mode
+    mode=$(/usr/bin/stat -f "%Lp" "$path" 2>/dev/null)
+    if [[ "$mode" == "$expected" ]]; then
+        ok "$path mode is $mode (expected $expected)"
+    else
+        fail "$path mode is $mode, expected $expected"
+    fi
+}
+if [[ -d "$SUPPORT_DIR" ]]; then
+    check_mode "$SUPPORT_DIR" "755"
+    check_mode "$SUPPORT_DIR/config.json" "600"
+    check_mode "$SUPPORT_DIR/ip_cache.json" "600"
+    check_mode "$SUPPORT_DIR/hosts.backup" "600"
+fi
+
+# 7. Launch daemon plists
 report_plist() {
     local path="$1"
     local label="$2"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -112,8 +112,11 @@ check_mode() {
 }
 if [[ -d "$SUPPORT_DIR" ]]; then
     check_mode "$SUPPORT_DIR" "755"
-    check_mode "$SUPPORT_DIR/config.json" "600"
-    check_mode "$SUPPORT_DIR/ip_cache.json" "600"
+    # config.json + ip_cache.json must be world-readable (0644) so the
+    # unprivileged app can check block state; root-only write protects
+    # against tampering. See #24.
+    check_mode "$SUPPORT_DIR/config.json" "644"
+    check_mode "$SUPPORT_DIR/ip_cache.json" "644"
     check_mode "$SUPPORT_DIR/hosts.backup" "600"
 fi
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# MonkMode uninstaller.
+#
+# Removes every file, daemon, and system modification the app installs.
+# Safe to re-run. Requires sudo because it touches /etc, /Library/LaunchDaemons,
+# and /usr/local/bin.
+#
+# Usage:
+#   sudo ./uninstall.sh                 # normal uninstall, keeps /Applications/MonkMode.app
+#   sudo ./uninstall.sh --delete-app    # also removes /Applications/MonkMode.app
+
+set -u
+DELETE_APP=0
+if [ "${1:-}" = "--delete-app" ]; then
+  DELETE_APP=1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "error: run with sudo (needs root to touch /etc and /Library/LaunchDaemons)" >&2
+  exit 1
+fi
+
+log() { echo "[uninstall] $*"; }
+
+SUPPORT_DIR="/Library/Application Support/MonkMode"
+LEGACY_SUPPORT_DIRS=(
+  "/Library/Application Support/BlockSites"
+  "/Library/Application Support/SelfControl"
+)
+
+DAEMON_LABELS=(
+  com.monkmode.enforcer
+  com.monkmode.cleanup
+  com.blocksites.enforcer
+  com.blocksites.cleanup
+  com.selfcontrol.enforcer
+  com.selfcontrol.cleanup
+)
+
+DAEMON_PLISTS=(
+  /Library/LaunchDaemons/com.monkmode.enforcer.plist
+  /Library/LaunchDaemons/com.monkmode.cleanup.plist
+  /Library/LaunchDaemons/com.blocksites.enforcer.plist
+  /Library/LaunchDaemons/com.blocksites.cleanup.plist
+  /Library/LaunchDaemons/com.selfcontrol.enforcer.plist
+  /Library/LaunchDaemons/com.selfcontrol.cleanup.plist
+)
+
+ENFORCER_BINARIES=(
+  /usr/local/bin/monkmode-enforcer
+  /usr/local/bin/monkmode
+  /usr/local/bin/selfcontrol-enforcer
+  /usr/local/bin/selfcontrol
+  /usr/local/bin/blocksites-enforcer
+  /usr/local/bin/blocksites
+)
+
+PF_ANCHORS=(
+  /etc/pf.anchors/com.monkmode
+  /etc/pf.anchors/com.blocksites
+  /etc/pf.anchors/com.selfcontrol
+)
+
+log "1/6 — stopping LaunchDaemons"
+for label in "${DAEMON_LABELS[@]}"; do
+  /bin/launchctl unload -w "/Library/LaunchDaemons/${label}.plist" >/dev/null 2>&1 || true
+  /bin/launchctl remove "${label}" >/dev/null 2>&1 || true
+done
+for plist in "${DAEMON_PLISTS[@]}"; do
+  [ -e "$plist" ] && rm -f "$plist" && log "    removed $plist"
+done
+
+log "2/6 — cleaning /etc/hosts"
+for marker in "# MONKMODE" "# BLOCKSITES" "# SELFCONTROL"; do
+  if grep -q "$marker" /etc/hosts 2>/dev/null; then
+    sed -i '' "/$marker/d" /etc/hosts
+    log "    stripped '$marker' entries"
+  fi
+done
+
+log "3/6 — cleaning /etc/pf.conf and pf anchors"
+for anchor_name in "com.monkmode" "com.blocksites" "com.selfcontrol"; do
+  if grep -q "\"$anchor_name\"" /etc/pf.conf 2>/dev/null; then
+    sed -i '' "/$anchor_name/d" /etc/pf.conf
+    log "    stripped '$anchor_name' anchor lines from pf.conf"
+  fi
+done
+/sbin/pfctl -d >/dev/null 2>&1 || true
+/sbin/pfctl -f /etc/pf.conf >/dev/null 2>&1 || true
+for anchor in "${PF_ANCHORS[@]}"; do
+  [ -e "$anchor" ] && rm -f "$anchor" && log "    removed $anchor"
+done
+
+log "4/6 — removing installed enforcer binaries"
+for bin in "${ENFORCER_BINARIES[@]}"; do
+  [ -e "$bin" ] && rm -f "$bin" && log "    removed $bin"
+done
+
+log "5/6 — removing application support directories"
+for dir in "$SUPPORT_DIR" "${LEGACY_SUPPORT_DIRS[@]}"; do
+  [ -d "$dir" ] && rm -rf "$dir" && log "    removed $dir"
+done
+
+log "6/6 — flushing DNS cache"
+/usr/bin/dscacheutil -flushcache >/dev/null 2>&1 || true
+/usr/bin/killall -HUP mDNSResponder >/dev/null 2>&1 || true
+
+if [ "$DELETE_APP" -eq 1 ]; then
+  for app in /Applications/MonkMode.app /Applications/SelfControl.app; do
+    [ -d "$app" ] && rm -rf "$app" && log "    removed $app"
+  done
+fi
+
+log "done. MonkMode has been fully uninstalled."
+if [ "$DELETE_APP" -eq 0 ] && [ -d /Applications/MonkMode.app ]; then
+  log "note: /Applications/MonkMode.app was left in place. Pass --delete-app to remove it, or drag it to the Trash manually."
+fi


### PR DESCRIPTION
## Summary

Phase 4 of the security program (#14).

### Changes

**#22 — First-class uninstaller**
- \`scripts/uninstall.sh\` removes every system modification MonkMode installs: daemons (current + legacy BlockSites / SelfControl), enforcer binaries, support dirs, hosts markers, pf anchors, pf anchor files. Idempotent, safe to re-run.
- Shipped inside the DMG (next to the .app) so a user who drags the .app to Trash still has a path to clean state.
- Also copied into \`MonkMode.app/Contents/Resources/\` so the in-app \"uninstall monkmode\" link under the execute button can invoke it via \`PrivilegedExecutor\`.

**#24 — Permissions hardening**
- Support directory \`chown root:wheel\`, \`chmod 0755\`.
- \`config.json\` + \`ip_cache.json\` set to \`0644\` (world-read, root-write) so the unprivileged app can check block state but a second local user cannot shorten the timer. A previous attempt at \`0600\` broke the app's read path and surfaced a phantom \"STALE LOCKDOWN DETECTED\" banner — fixed in the same branch.
- \`hosts.backup\` stays \`0600\` because it mirrors the user's full \`/etc/hosts\`.
- \`install.log\` at \`0640\`.
- Smoke test asserts all of the above.

**#25 — Log hygiene**
- \`enforcer.log\` rotates at 1 MB → \`.log.1\`, capping at ~2 MB total.
- \`redact()\` replaces any domain-shaped token in log messages with \`<domain>\`. Toggle off with \`MONKMODE_LOG_VERBOSE=1\` in the daemon env.
- \`SECURITY.md\` now documents the full per-file matrix (mode, content, redaction policy) and reaffirms the \"zero telemetry\" posture.

### Issues also advanced

- PR resolves a user-facing regression from #24 where the initial \`0600\` mode broke the app's read of \`config.json\` and caused the stale-lockdown banner to fire over an active block.
- Enforcer source-path fix (#15 regression) shipped separately as PR #33 earlier this session.

Closes #22
Closes #24
Closes #25

Part of #14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added uninstall functionality to completely remove the application and all system components.
  * Enhanced logging with automatic sensitive data redaction and log rotation capabilities.
  * Added verbose logging mode for debugging via environment variable.

* **Documentation**
  * Added comprehensive security policy documenting logging behavior, data storage, and privacy practices.

* **Chores**
  * Updated build system to include uninstall helper in distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->