### PR TITLE
fix: smooth 1s countdown + block IPv6 in /etc/hosts

### DIFF
--- a/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
+++ b/Sources/BlockSitesApp/ViewModels/BlockViewModel.swift
@@ -286,16 +286,9 @@ class BlockViewModel: ObservableObject {
     private func startCountdownTimer() {
         timer?.invalidate()
 
-        let interval: TimeInterval
-        if remainingSeconds <= 60 {
-            interval = 1
-        } else if remainingSeconds <= 3600 {
-            interval = 10
-        } else {
-            interval = 60
-        }
-
-        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+        // Always tick at 1s so the displayed HH:MM:SS counts down smoothly.
+        // CPU cost is negligible — a single timer firing once per second.
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
             guard let self = self, let config = self.config else { return }
             let remaining = config.endTime.timeIntervalSince(Date())
             if remaining <= 0 {
@@ -314,11 +307,6 @@ class BlockViewModel: ObservableObject {
                 self.startPostExpiryPolling()
             } else {
                 self.remainingSeconds = remaining
-                if remaining <= 60 && interval != 1 {
-                    self.startCountdownTimer()
-                } else if remaining <= 3600 && interval > 10 {
-                    self.startCountdownTimer()
-                }
             }
         }
     }

--- a/Sources/BlockSitesCore/HostsGenerator.swift
+++ b/Sources/BlockSitesCore/HostsGenerator.swift
@@ -1,21 +1,26 @@
 import Foundation
 
 public enum HostsGenerator {
-    /// Generates hosts file entries for the given sites, marked with the specified marker.
-    /// Also includes DNS-over-HTTPS provider domains to force browsers to use system DNS.
+    /// Generates hosts file entries for the given sites, marked with the
+    /// specified marker. Writes both an IPv4 (`127.0.0.1`) and an IPv6
+    /// (`::1`) mapping for every domain so browsers asking for an AAAA
+    /// record cannot bypass the block via IPv6.
+    ///
+    /// Also adds DNS-over-HTTPS provider domains so browsers are forced to
+    /// use the system resolver, which honours `/etc/hosts`.
     public static func generateHostsEntries(for sites: [String], marker: String = "# MONKMODE") -> String {
         var blockEntries = "\n\(marker) START\n"
         for site in sites {
             let domains = DomainExpander.expandDomains(for: site)
             for domain in domains {
                 blockEntries += "127.0.0.1 \(domain) \(marker)\n"
+                blockEntries += "::1 \(domain) \(marker)\n"
             }
         }
 
-        // Block DNS-over-HTTPS providers to force browsers to use system DNS
-        // (which respects /etc/hosts entries)
         for domain in DomainExpander.dohDomains {
             blockEntries += "127.0.0.1 \(domain) \(marker)\n"
+            blockEntries += "::1 \(domain) \(marker)\n"
         }
 
         blockEntries += "\(marker) END\n"


### PR DESCRIPTION
Two user-reported bugs:

- **Countdown looked stuck**: timer ticked every 10s while remaining was 1m–1h and every 60s above that, so the HH:MM:SS display jumped in chunks. Switch to an unconditional 1s tick.
- **LinkedIn (and similar IPv6-preferring sites) bypassed the block**: \`/etc/hosts\` only had IPv4 \`127.0.0.1\` entries. Browsers asking for an AAAA record got the real IPv6 address. Now every blocked domain gets both a \`127.0.0.1\` and a \`::1\` mapping under the MONKMODE marker; same for the DoH provider list.