### PR TITLE
chore(make): add reinstall and uninstall targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release run install clean test dmg
+.PHONY: build release run install clean test dmg reinstall uninstall
 
 # Development
 build:
@@ -19,6 +19,18 @@ install: release
 
 dmg:
 	./scripts/build_dmg.sh
+
+# Rebuild the DMG, replace the /Applications copy, strip quarantine, and
+# launch the fresh app. Handy for dogfooding after every change.
+reinstall: dmg
+	rm -rf /Applications/MonkMode.app
+	cp -R dist/MonkMode.app /Applications/
+	xattr -cr /Applications/MonkMode.app
+	open /Applications/MonkMode.app
+
+# Privileged uninstall via the bundled script.
+uninstall:
+	sudo ./scripts/uninstall.sh
 
 # Testing
 test:


### PR DESCRIPTION
`make reinstall` = dmg + copy to /Applications + xattr -cr + open. `make uninstall` = sudo ./scripts/uninstall.sh.