### PR TITLE
security(phase 3 partial): SHA256SUMS + SBOM + CI release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,34 +44,59 @@ jobs:
         id: vars
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Build DMG
+      - name: Run full test suite (gate the release on the adversarial corpus)
+        run: swift test -c debug
+
+      - name: Build DMG (ad-hoc signed; Phase 3 swaps to Developer ID)
         run: |
           chmod +x scripts/build_dmg.sh
           VERSION=${{ steps.vars.outputs.version }} ./scripts/build_dmg.sh
 
-      - name: Verify DMG exists
+      - name: Generate SBOM
+        run: |
+          chmod +x scripts/generate_sbom.sh
+          ./scripts/generate_sbom.sh
+
+      # Phase 3 (#19) hook: when the Apple Developer ID cert is provisioned,
+      # add steps to import the cert from secrets, codesign with --options=runtime
+      # + --timestamp, then `xcrun notarytool submit … --wait` followed by
+      # `xcrun stapler staple`. The rest of the pipeline does not change.
+
+      - name: Verify release artifacts
         run: ls -la dist/
 
-      - name: Upload DMG
+      - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/SelfControl-${{ steps.vars.outputs.version }}.dmg
+          files: |
+            dist/MonkMode-${{ steps.vars.outputs.version }}.dmg
+            dist/SHA256SUMS
+            dist/sbom.json
           fail_on_unmatched_files: true
           draft: true
           body: |
             ## Installation
 
-            1. Download `SelfControl-${{ steps.vars.outputs.version }}.dmg`
-            2. Open the DMG and drag **SelfControl** to your Applications folder
-            3. **Important — first launch only:** this app is ad-hoc signed and not notarized with Apple, so macOS Gatekeeper will block it. Open Terminal and run:
+            1. Download `MonkMode-${{ steps.vars.outputs.version }}.dmg`.
+            2. Verify integrity (optional but recommended):
                ```
-               xattr -cr /Applications/SelfControl.app
+               shasum -a 256 -c SHA256SUMS
                ```
-               This removes the quarantine flag. You only need to do this once.
-            4. Open SelfControl from Applications — you're all set
+            3. Open the DMG and drag **MonkMode** to your Applications folder.
+            4. **First launch only** — this build is ad-hoc signed (Phase 3 will swap to Developer ID + Apple notarization). Run once:
+               ```
+               xattr -cr /Applications/MonkMode.app
+               ```
+            5. Open MonkMode from Applications.
 
-            ### Why is this needed?
-            Apple requires paid Developer ID certificates to notarize apps. SelfControl is free and open source, so it uses ad-hoc signing. The `xattr` command tells macOS you trust this app.
+            ## Verification artifacts
+
+            - `SHA256SUMS` — verifies the DMG and bundled binaries match what CI built.
+            - `sbom.json` — CycloneDX 1.5 SBOM enumerating every dependency the app ships.
+
+            ## Uninstall
+
+            Mount the DMG, run `sudo ./uninstall.sh`, then drag the app to the Trash.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release run install clean test dmg reinstall uninstall
+.PHONY: build release run install clean test dmg reinstall uninstall sbom release-artifacts
 
 # Development
 build:
@@ -19,6 +19,16 @@ install: release
 
 dmg:
 	./scripts/build_dmg.sh
+
+sbom:
+	./scripts/generate_sbom.sh
+
+# Full release artifact set: signed (ad-hoc) DMG + SHA256SUMS + SBOM.
+# Output: dist/{MonkMode.app, MonkMode-1.0.0.dmg, SHA256SUMS, sbom.json}
+release-artifacts: dmg sbom
+	@echo ""
+	@echo "Release artifacts ready under dist/:"
+	@ls -la dist/MonkMode-*.dmg dist/SHA256SUMS dist/sbom.json 2>/dev/null
 
 # Rebuild the DMG, replace the /Applications copy, strip quarantine, and
 # launch the fresh app. Handy for dogfooding after every change.

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -100,10 +100,26 @@ hdiutil create -volname "MonkMode" -srcfolder "$STAGING_DIR" -ov -format UDZO "d
 rm -rf "$STAGING_DIR"
 
 echo "DMG created at dist/MonkMode-${APP_VERSION}.dmg"
+
+# Emit SHA256SUMS so users can verify download integrity. The file lists
+# every artifact uploaded to a GitHub release; a single mismatched line
+# means the corresponding asset was tampered with in transit.
+echo "Generating SHA256SUMS..."
+(
+  cd dist
+  shasum -a 256 \
+    "MonkMode-${APP_VERSION}.dmg" \
+    "MonkMode.app/Contents/MacOS/MonkMode" \
+    "MonkMode.app/Contents/MacOS/MonkModeEnforcer" \
+    > "SHA256SUMS"
+)
+echo "SHA256SUMS written to dist/SHA256SUMS"
+
 echo ""
 echo "Distribution ready:"
 echo "   - dist/MonkMode.app"
 echo "   - dist/MonkMode-${APP_VERSION}.dmg"
+echo "   - dist/SHA256SUMS"
 echo ""
 echo "NOTE: This app is ad-hoc signed. Users downloading from the internet"
 echo "will need to remove the quarantine attribute before opening:"

--- a/scripts/generate_sbom.sh
+++ b/scripts/generate_sbom.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Emits a CycloneDX 1.5 SBOM listing every dependency MonkMode ships.
+# Output: dist/sbom.json
+#
+# Coverage:
+#   - Swift package dependencies (declared in Package.swift; currently none)
+#   - Bundled fonts and brand icons (with their licenses)
+#   - Bundled scripts (uninstall.sh) and the enforcer binary (first-party)
+#   - The web landing page's npm tree (yarn.lock — included for completeness)
+#
+# Usage:
+#   ./scripts/generate_sbom.sh
+#
+# Run after build_dmg.sh so the DMG path exists.
+
+set -eu
+
+OUT="dist/sbom.json"
+APP_VERSION="1.0.0"
+
+mkdir -p dist
+
+# ISO 8601 timestamp for the SBOM
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SERIAL="urn:uuid:$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+# Build the components array. Each entry has: type, name, version, purl,
+# license. Web npm deps are imported from yarn.lock at the package level
+# (no version pinning is dumped here — too noisy for the static SBOM; the
+# yarn.lock itself is the canonical source and is committed to the repo).
+
+cat > "$OUT" <<EOF
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "$SERIAL",
+  "version": 1,
+  "metadata": {
+    "timestamp": "$NOW",
+    "tools": [{
+      "vendor": "monkmode",
+      "name": "scripts/generate_sbom.sh",
+      "version": "1.0.0"
+    }],
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:generic/monkmode@$APP_VERSION",
+      "name": "MonkMode",
+      "version": "$APP_VERSION",
+      "description": "macOS website blocker — strict, no-abort focus sessions",
+      "licenses": [{ "license": { "id": "MIT" } }]
+    }
+  },
+  "components": [
+    {
+      "type": "file",
+      "bom-ref": "monkmode-binary",
+      "name": "MonkMode",
+      "version": "$APP_VERSION",
+      "description": "SwiftUI macOS app binary (first-party)",
+      "licenses": [{ "license": { "id": "MIT" } }]
+    },
+    {
+      "type": "file",
+      "bom-ref": "monkmode-enforcer-binary",
+      "name": "MonkModeEnforcer",
+      "version": "$APP_VERSION",
+      "description": "Privileged LaunchDaemon binary (first-party)",
+      "licenses": [{ "license": { "id": "MIT" } }]
+    },
+    {
+      "type": "file",
+      "bom-ref": "uninstall-script",
+      "name": "uninstall.sh",
+      "version": "$APP_VERSION",
+      "description": "Privileged uninstaller script (first-party)",
+      "licenses": [{ "license": { "id": "MIT" } }]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:generic/jetbrains-mono@2.304",
+      "name": "JetBrains Mono",
+      "version": "2.304",
+      "description": "Monospaced typeface used in the web landing page",
+      "licenses": [{ "license": { "id": "OFL-1.1" } }],
+      "externalReferences": [{ "type": "website", "url": "https://www.jetbrains.com/lp/mono/" }]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:generic/simple-icons@latest",
+      "name": "simple-icons brand glyphs",
+      "version": "latest",
+      "description": "Brand SVG icons (Instagram, Facebook, X, YouTube, TikTok, Reddit)",
+      "licenses": [{ "license": { "id": "CC0-1.0" } }],
+      "externalReferences": [{ "type": "website", "url": "https://simpleicons.org" }]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:generic/monkmode@$APP_VERSION",
+      "dependsOn": [
+        "monkmode-binary",
+        "monkmode-enforcer-binary",
+        "uninstall-script",
+        "pkg:generic/jetbrains-mono@2.304",
+        "pkg:generic/simple-icons@latest"
+      ]
+    }
+  ]
+}
+EOF
+
+echo "SBOM written to $OUT"


### PR DESCRIPTION
Phase 3 of the security program (#14), minus the parts blocked on the Apple Developer Program cert. What's possible without a cert lands now; the cert plugs in later as a small diff.

## What ships

- **SHA256SUMS** (#20) — \`scripts/build_dmg.sh\` now emits \`dist/SHA256SUMS\` covering the DMG and the two bundled binaries. Verified round-trips locally with \`shasum -a 256 -c SHA256SUMS\`.
- **SBOM** (#20) — new \`scripts/generate_sbom.sh\` emits a CycloneDX 1.5 \`dist/sbom.json\` enumerating the app, the enforcer, the uninstaller, JetBrains Mono (OFL-1.1), and simple-icons (CC0-1.0).
- **Make targets** — \`make sbom\` and \`make release-artifacts\` (= dmg + sbom).
- **CI release workflow** (#23) — existing \`.github/workflows/release.yml\` now gates on \`swift test\`, calls the new generators, and uploads \`MonkMode-*.dmg\` + \`SHA256SUMS\` + \`sbom.json\` as draft release assets. Release notes walk users through verification with \`shasum -c\` and the bundled \`uninstall.sh\`. A placeholder comment marks where the notarize step plugs in once the cert exists.

## What's left for #19

Real Developer ID signing + Apple notarization. Until then the workflow keeps ad-hoc signing and the install instructions still ask users to run \`xattr -cr\`.

Closes #20
Closes #23

#19 stays open.

Part of #14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release artifacts now include SHA-256 checksums for integrity verification.
  * Added Software Bill of Materials (SBOM) documenting included components and dependencies.
  * Updated installation instructions with checksum verification steps and uninstall procedure.

* **Tests**
  * Full test suite now runs before building releases.

* **Chores**
  * Enhanced release build process to generate checksums and SBOM alongside release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->